### PR TITLE
Correct CI reference to reusable workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,6 @@ on:
 jobs:
   lint_and_test:
     name: lint and test
-    uses: developerproductivity/logilica-weekly-report/.github/workflows/python_lint_and_test.yaml@add-CI
+    uses: developerproductivity/logilica-weekly-report/.github/workflows/python_lint_and_test.yaml@main
     with:
       python_versions: ${{ vars.DEVELOPERPRODUCTIVITY_PYTHON_VERSIONS }}


### PR DESCRIPTION
When I merged #2, I neglected to change the reference for the reusable workflow from the test branch to `main`.