### PR TITLE
Rework linter configurations

### DIFF
--- a/.github/workflows/python_lint_and_test.yaml
+++ b/.github/workflows/python_lint_and_test.yaml
@@ -28,14 +28,13 @@ jobs:
           python -m pip install -r requirements.txt -r tests/requirements.txt -r .github/workflows/requirements.txt
       - name: Run python style and linting tools
         run: |
-          pip install autoflake black docformatter flake8 isort
           err=0
           echo autoflake:
-          autoflake --check --remove-all-unused-imports --remove-unused-variables . || err=$?
+          autoflake --check-diff . || err=$?
           echo black:
           black --check . || err=$?
           echo docformatter:
-          docformatter --check --recursive --black --wrap-descriptions 79 --wrap-summaries 79 . || err=$?
+          docformatter . || err=$?
           echo flake8:
           flake8 . || err=$?
           echo isort:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,24 @@
+[tool.autoflake]
+exclude = ["build"]
+recursive = true
+remove-all-unused-imports = true
+remove-unused-variables = true
+
 [tool.black]
 skip-string-normalization = false
 skip-magic-trailing-comma = false
 include = '\.pyi?$'
+
+[tool.docformatter]
+black = true
+close-quotes-on-newline = true
+exclude = "build"
+recursive = true
+wrap-descriptions = 79
+wrap-summaries = 79
 
 [tool.isort]
 profile = "black"                 # black-compatible (e.g., trailing comma)
 #known_first_party = ["relay"]     # use separate section for project sources
 force_sort_within_sections = true # don't separate import vs from
 order_by_type = false             # sort alphabetic regardless of case
-


### PR DESCRIPTION
This PR moves the individual linter configuration options from command line switches in the CI workflow to the `pyproject.toml` file, so that they are trivially available to the developers in their own environments.  That is, both the CI and the developer can use a command line like `docformatter .` and get the same options and therefore the same results.  Hopefully this will simplify things in multiple ways for us.

This PR also includes some other small changes:
- remove the explicit `pip install` of the CI's linter packages -- these are already installed in the previous workflow "step", via the `requirements.txt` file, so this command just produces useless noise in the log
- change the options on `autoflake` and `docformatter` so that they will dump any objections to the CI's log instead of just noting that issues exist
- configure `autoflake` and `docformatter` to ignore the `build` subdirectory tree (`black` and the others do this by default)
- configure `autoflake` to search recursively for sources (the others already do this)
- configure `docformatter`to place the closing docstring quotes on their own line when the docstring wraps