### PR TITLE
Generate HTML output

### DIFF
--- a/logilica_weekly_report/download_pdfs.py
+++ b/logilica_weekly_report/download_pdfs.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 from typing import Optional
 
-from playwright.sync_api import Page, sync_playwright
+from playwright.sync_api import expect, Page, sync_playwright
 
 LOGILICA_LOGIN = "https://logilica.io/login"
 
@@ -32,8 +32,9 @@ def download_pdfs(teams_config: dict[str, any], download_path: pathlib.Path) -> 
                 page.locator("#email").fill(os.getenv("LOGILICA_EMAIL"))
                 page.locator("#password").fill(os.getenv("LOGILICA_PASSWORD"))
                 page.get_by_role("button", name="Login").click()
-
-                if page.url == LOGILICA_LOGIN:
+                try:
+                    expect(page).not_to_have_url(LOGILICA_LOGIN)
+                except AssertionError:
                     logging.error("Login failed")
                     raise ValueError("Login credentials rejected")
                 logging.debug("Login to Logilica complete")

--- a/logilica_weekly_report/pdf_extract.py
+++ b/logilica_weekly_report/pdf_extract.py
@@ -4,19 +4,25 @@
 #
 import logging
 import pathlib
-from typing import Any, Union
+from typing import Any, NamedTuple
 
-from PIL.PngImagePlugin import ImageFile
-from pypdf import PdfReader
+import pymupdf
 
-PDF_ITEMS = dict[str, Union[list[str], dict[str, ImageFile]]]
+# Choosing a higher image DPI produces a finer quality image but a larger
+# amount of data; it also affects the sizes of the headers and footers; so,
+# everything is parameterized by SCALE.
+SCALE = 20
+IMAGE_DPI = 30 * SCALE  # Resolution for images
+REPORT_HEADER_HEIGHT = 39 * SCALE + 4  # (256 + 134)@300dpi + fudge
+PAGE_HEADER_HEIGHT = 5 * SCALE
+PAGE_FOOTER_HEIGHT = 18 * SCALE
 
 
 def get_pdf_objects(
     teams_config: dict[str, dict[str, Any]],
     download_path: pathlib.Path,
-) -> dict[str, dict[str, PDF_ITEMS]]:
-    """Extract all images and text from the configured PDF files.
+) -> dict[str, dict[str, bytes]]:
+    """Extract content from the configured PDF files.
 
     Assumes that the teams configuration is a dictionary whose keys are the
     teams' names (e.g., "Practices Team") and whose values are dictionaries
@@ -25,31 +31,93 @@ def get_pdf_objects(
           team_dashboards:
             Developer Practices Dashboard:
               Filename: DPROD_Report.pdf
+            DPROD Dashboard 2:
+              Filename: DPROD_Report2.pdf
             ...
         ...
 
     Returns a hierarchical set of dictionaries:
       - the first level keys are the teams' names
       - the second level keys are the Dashboard names
-      - the third level keys are "images" or "text"
-      - the value of the "images" key is a mapping of image names to JPEG contents
-      - the value of the "text" key is a list of text blobs
+      - the values are the contents of the Dashboards as PNG images
     """
     results = {}
     for team, dashboards in teams_config.items():
         team_results = {}
         for dashboard, options in dashboards["team_dashboards"].items():
-            logging.debug("Extracting items from '%s' for %s", dashboard, team)
-            dashboard_results = {"images": {}, "text": []}
-            pdf = PdfReader(download_path / options["Filename"])
-            for page in pdf.pages:
-                i = {image.name: image.image for image in page.images}
-                t = page.extract_text(
-                    extraction_mode="layout",
-                    layout_mode_space_vertically=False,
-                )
-                dashboard_results["images"].update(i)
-                dashboard_results["text"].append(t)
-            team_results[dashboard] = dashboard_results
+            logging.info("Extracting items from '%s' for %s", dashboard, team)
+            pdf: pymupdf.Document
+            with pymupdf.open(download_path / options["Filename"]) as pdf:
+                team_results[dashboard] = get_report_image(pdf)
         results[team] = team_results
     return results
+
+
+def get_report_image(pdf: pymupdf.Document) -> bytes:
+    """Render the PDF, with the pages knitted together, as a single image.
+
+    The individual pages' pixmaps are copied to adjacent locations in the
+    target pixmap.  In the process, page headers, footers, and trailing
+    whitespace are omitted.  The pixmap is returned as a byte-string.
+    """
+
+    class PageArea(NamedTuple):
+        offset: int
+        length: int
+
+    # Calculate and record the length required for each page; track the total
+    # length.
+    page_areas: list[PageArea] = []
+    total_length = 0
+    for i, page in enumerate(iter(pdf)):
+        offset = REPORT_HEADER_HEIGHT if i == 0 else PAGE_HEADER_HEIGHT
+        pix: pymupdf.Pixmap = page.get_pixmap(dpi=IMAGE_DPI)
+        pl = strip_trailing_space(pix) - offset
+        page_areas.append(PageArea(offset, pl))
+        total_length += pl
+
+    # Create the target pixmap based on the characteristics of the first page
+    # and the total length of all the pages.
+    base_pixmap: pymupdf.Pixmap = pdf[0].get_pixmap(dpi=IMAGE_DPI)
+    d_image = pymupdf.Pixmap(
+        base_pixmap.colorspace,
+        (0, 0, base_pixmap.width, total_length),
+        base_pixmap.alpha,
+    )
+
+    # Locate each page region and copy it to the appropriate place in the
+    # destination pixmap.
+    dest_start = 0
+    for i, page in enumerate(iter(pdf)):
+        pix: pymupdf.Pixmap = page.get_pixmap(dpi=IMAGE_DPI)
+        pix.set_origin(0, dest_start - page_areas[i].offset)
+        dest_end = dest_start + page_areas[i].length
+        dest_rect = (0, dest_start, pix.width, dest_end)
+        d_image.copy(pix, dest_rect)
+        dest_start = dest_end
+    return d_image.tobytes(output="png")
+
+
+def strip_trailing_space(pix: pymupdf.Pixmap) -> int:
+    """Returns the height coordinate of the last row of pixels which is
+    different from the first row of the footer; assuming that the first row of
+    the footer is "blank", this returns the height at which to truncate the
+    pixmap to remove the trailing whitespace.
+    """
+    # The pixmap is structured as a linear serialization of a three-dimensional
+    # array of pixels: "height" rows, by "width" columns, by 'n' items
+    # representing (e.g.) red, green, blue, and transparency values as integers.
+    # The stride indicates how many items are in a single row.  Find the index
+    # of the first row of the footer (which we assume is blank), and grab a
+    # reference to it.
+    stride: int = pix.stride
+    footer_row_idx: int = (pix.height - PAGE_FOOTER_HEIGHT) * stride
+    blank_row = pix.samples_mv[footer_row_idx : footer_row_idx + stride]
+
+    # Starting at the last row before the footer, work backwards looking for a
+    # row whose values are different from those of a "blank" row.
+    for pos in range(footer_row_idx - stride, 0, -stride):
+        if pix.samples_mv[pos : pos + stride] != blank_row:
+            return pos // stride
+
+    raise ValueError("Page appears to be blank!")

--- a/logilica_weekly_report/update_gdoc.py
+++ b/logilica_weekly_report/update_gdoc.py
@@ -1,12 +1,46 @@
-def update_gdoc(pdf_items: dict[str, dict[str, any]], config: dict[str, any]) -> None:
+import base64
+from typing import Callable
+
+from yattag import Doc, SimpleDoc
+
+
+def update_gdoc(pdf_items: dict[str, dict[str, bytes]], config: dict[str, any]) -> None:
     """Take the set of charts and text extracted from the PDF and insert it
     into the Google Doc.
+
+    This is accomplished by generating an HTML document and uploading it to
+    Google Drive with a MIME type of `'application/vnd.google-apps.document'`,
+    which causes Google to treat/convert it to a GDoc.  The images are inserted
+    into it as data URIs, which Google will manage appropriately.
     """
 
-    # Debug stand-in code
-    for team, i in pdf_items.items():
-        for dashboard, j in i.items():
-            for name, content in j["images"].items():
-                print(f"{team} {dashboard} {name}:  {content.width}x{content.height}")
-            for k, text in enumerate(j["text"]):
-                print(f"{team} {dashboard} text blob #{k}:  {len(text)} characters")
+    doc, tag, text = Doc().tagtext()
+
+    doc.asis("<!DOCTYPE html>")
+    with tag("html"):
+        with tag("body"):
+            with tag("h1"):
+                text("Logilica Weekly Report")
+                add_teams(pdf_items, doc, tag, text)
+
+    print(doc.getvalue())
+
+
+def add_teams(
+    pdf_items: dict[str, dict[str, bytes]],
+    doc: SimpleDoc,
+    tag: Callable[[str], SimpleDoc.Tag],
+    text: Callable[[str], None],
+):
+    for team, dashboards in pdf_items.items():
+        doc.asis("<hr>")
+        with tag("h2"):
+            text(team)
+        for dashboard, contents in dashboards.items():
+            image_data = base64.b64encode(contents).decode()
+            doc.stag(
+                "img",
+                src="data:image/png;base64," + image_data,
+                width="80%",
+                height="80%",
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,9 @@ profile = "black"                               # black-compatible (e.g., traili
 known_first_party = ["logilica_weekly_report"]  # use separate section for project sources
 force_sort_within_sections = true               # don't separate import vs from
 order_by_type = false                           # sort alphabetic regardless of case
+
+[tool.setuptools]
+packages = ["logilica_weekly_report"]
+
+[tool.setuptools.dynamic]
+dependencies = { file = "requirements.txt" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click~=8.1.0
-pillow~=11.0.0
 playwright~=1.49.0
-pypdf~=5.1.0
+PyMuPDF~=1.25.2
 pyyaml~=6.0.2
+yattag~=1.16.1

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -16,14 +16,19 @@ class MyTestCase(unittest.TestCase):
 
         result = get_pdf_objects(config, pathlib.Path(__file__).parent / "fixtures")
         self.assertEqual(
-            3,
-            len(result["Mock Team"]["Mock Team Dashboard"]["text"]),
-            "Unexpected number of text sections found.",
+            1,
+            len(result),
+            "Unexpected number of teams found.",
         )
         self.assertEqual(
-            5,
-            len(result["Mock Team"]["Mock Team Dashboard"]["images"]),
-            "Unexpected number of images sections found.",
+            1,
+            len(result["Mock Team"]),
+            "Unexpected number of dashboards found.",
+        )
+        self.assertEqual(
+            1360589,
+            len(result["Mock Team"]["Mock Team Dashboard"]),
+            "Unexpected images size found.",
         )
 
 


### PR DESCRIPTION
This change builds on #7, replacing the stub output functionality with full HTML output including embedded images of the teams' dashboards.

The `update_gdoc()` function now generates an HTML document, which it dumps to `stdout`  (temporarily -- a follow-on PR will take this content and use it to create a Google Document).  The document consists of an `h1` header followed by a series of `hr`-`h2`-`img` sequences with the team name as the header and the team dashboard(s) as in-line image(s).

In order to make this work, this change reworks the PDF processing, replacing the previous "extraction" process with one which renders each dashboard PDF as a single image.  This was required in order to properly capture the graphs, which are part image and part overlaid text.  In order to implement this, the use of the `pypdf` (and `PIL`) package(s) was replaced with the `pymupdf` package which does the page rendering.  In addition, for reports which constitute multiple pages, the tool "knits" the pages together into a single image, removing page headers and footers (and trailing whitespace) to produce a continuous-flow image suitable for display on a web page.  (And, the function interface was updated to return only image data instead of image+text.)

Note that the page layout is determined by the original report design and dictated by Logilica's PDF rendering.  This tool simply renders the reports as images and wraps them in a simple HTML document, so, generally speaking, if we don't like the formatting, we need to take it up with the report designer and/or Logilica -- there's not much that the tool can do about it (other than altering the images' size or resolution).

This PR also contains the following ancillary changes:
- The test which detects login failure on the Logilica web site is reworked to (hopefully) make it reliable.
- There are a couple of tweaks to the `setuptools` configuration in the `pyproject.toml` file.
- The `requirements.txt` file is updated to match the new code.

Other than loading the resulting image into a GDoc, another piece of functionality which is missing is the per-team selection of data filters:  currently, the tool makes no such selection, so the charts include all data which is accessible.  This is to be addressed in a future change, as well.