### PR TITLE
Upload generated HTML to Google Drive

### DIFF
--- a/logilica_weekly_report/update_gdoc.py
+++ b/logilica_weekly_report/update_gdoc.py
@@ -1,10 +1,28 @@
 import base64
-from typing import Callable
+from datetime import datetime
+from io import BytesIO
+import logging
+from pathlib import Path
+from typing import Callable, Literal, Optional
 
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaIoBaseUpload
+import platformdirs
 from yattag import Doc, SimpleDoc
 
+APPLICATION_NAME = "Logilica"
+DEFAULT_APP_CREDENTIALS_FILE_NAME = "application_default_credentials.json"
+DEFAULT_GDRIVE_FILE_TEMPLATE = "Logilica_Reports_{:%Y-%m-%d}"
+DEFAULT_TOKEN_FILE_NAME = "token.json"
 
-def update_gdoc(pdf_items: dict[str, dict[str, bytes]], config: dict[str, any]) -> None:
+
+def update_gdoc(
+    pdf_items: dict[str, dict[str, bytes]], creds: Credentials, config: dict[str, any]
+):
     """Take the set of charts and text extracted from the PDF and insert it
     into the Google Doc.
 
@@ -13,17 +31,22 @@ def update_gdoc(pdf_items: dict[str, dict[str, bytes]], config: dict[str, any]) 
     which causes Google to treat/convert it to a GDoc.  The images are inserted
     into it as data URIs, which Google will manage appropriately.
     """
+    doc = generate_html(pdf_items)
+    upload_doc(doc.getvalue(), creds, config)
 
+
+def generate_html(pdf_items: dict[str, dict[str, bytes]]) -> SimpleDoc:
+    """Generate an HTML document from the set of charts and text extracted from
+    the PDF.
+    """
     doc, tag, text = Doc().tagtext()
-
     doc.asis("<!DOCTYPE html>")
     with tag("html"):
         with tag("body"):
             with tag("h1"):
                 text("Logilica Weekly Report")
                 add_teams(pdf_items, doc, tag, text)
-
-    print(doc.getvalue())
+    return doc
 
 
 def add_teams(
@@ -44,3 +67,146 @@ def add_teams(
                 width="80%",
                 height="80%",
             )
+
+
+def upload_doc(doc: str, creds: Credentials, config: dict[str, any]) -> str:
+    """Upload the provided in-memory HTML document to Google Drive."""
+
+    filename = (
+        config.get("google", {})
+        .get("filename", DEFAULT_GDRIVE_FILE_TEMPLATE)
+        .format(datetime.now())
+    )
+    file_metadata = {
+        "name": filename,
+        "mimeType": "application/vnd.google-apps.document",
+    }
+    try:
+        service = build("drive", "v3", credentials=creds)
+        media = MediaIoBaseUpload(
+            BytesIO(doc.encode()), mimetype="text/html", resumable=True
+        )
+        request = service.files().create(
+            body=file_metadata,
+            fields="id",
+            media_body=media,
+            includeLabels=None,
+            includePermissionsForView=None,
+        )
+
+        response = None
+        while response is None:
+            status, response = request.next_chunk()
+            if status:
+                print(f"Uploaded {int(status.progress() * 100)}%.")
+        logging.info(
+            'File "%s" with ID "%s" has been uploaded.', filename, response.get("id")
+        )
+
+    except HttpError as error:
+        logging.error("An error occurred uploading %s: %s", filename, error)
+        raise
+
+    return response.get("id")
+
+
+def get_google_credentials(config: dict[str, any]) -> Credentials:
+    """Get the Google OAuth credentials needed to use Google Drive.
+
+    The token is obtained either using values cached in a local file or by
+    prompting the user to perform an authorization dialog; either way, the
+    new token is written to the cache file before returning.
+
+    The Google OAuth 2.0 Client "app" configuration is constructed from a local
+    credentials file (which can be downloaded from https://console.developers.google.com,
+    under "Credentials").  It is located using the default mechanisms (e.g., in
+    ${HOME}/.config/gcloud/application_default_credentials.json).  (Currently,
+    the scope of the authorization is limited to the Google Drive APIs.)
+    """
+    token_file = get_token_file(config)
+    logging.debug("Google OAuth token file: %s", token_file)
+    app_credentials_file = get_app_credentials_file(config)
+    logging.debug("Google app credentials file: %s", app_credentials_file)
+    scopes = ["https://www.googleapis.com/auth/drive.file"]
+
+    creds = None
+    # The token file stores the user's access and refresh tokens and is created
+    # automatically when the authorization flow completes for the first time.
+    if token_file.exists():
+        creds = Credentials.from_authorized_user_file(str(token_file), scopes)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            logging.info("Refreshing credentials.")
+            creds.refresh(Request())
+            logging.debug("Credentials refreshed successfully.")
+        else:
+            # Lead the user through a login using the browser
+            logging.info("Launching OAuth login dialog.")
+            flow = InstalledAppFlow.from_client_secrets_file(
+                str(app_credentials_file), scopes
+            )
+            creds = flow.run_local_server(port=0)
+            logging.debug("OAuth login successful.")
+        # Save the credentials for the next run
+        with open(token_file, "w") as token:
+            logging.info("Caching OAuth tokens.")
+            token.write(creds.to_json())
+    return creds
+
+
+def get_token_file(config: dict[str, any]) -> Path:
+    """Get the Path to the file for caching the OAuth tokens."""
+    return get_info_file(
+        config.get("google", {}).get("token_file"),
+        DEFAULT_TOKEN_FILE_NAME,
+        platformdirs.user_cache_path,
+    )
+
+
+def get_app_credentials_file(config: dict[str, any]) -> Path:
+    """Get the file containing the Google Client app credentials."""
+    return get_info_file(
+        config.get("google", {}).get("app_credentials_file"),
+        DEFAULT_APP_CREDENTIALS_FILE_NAME,
+        platformdirs.user_config_path,
+    )
+
+
+def get_info_file(
+    config_string: Optional[str],
+    default_file_name: Optional[str],
+    get_platform_path: Callable[
+        [str | None, str | None | Literal[False], str | None, bool, bool], Path
+    ],
+) -> Path:
+    """Generate the file path, based on the tool configuration with supplied
+    defaults for the file name and platform directory locations, creating the
+    parent directories if necessary.
+    """
+
+    if not config_string:
+        config_string = ""
+
+    # The pathlib handling doesn't discriminate well between files and
+    # directories -- they are all "paths" (e.g., it strips superfluous slashes,
+    # including trailing ones) -- so, if the input string ends in a slash, take
+    # it all as the directory path; otherwise, assume the last "part" is a file
+    # name.
+    filename = ""
+    ipath = Path(config_string)
+    if not config_string.endswith("/"):
+        filename = ipath.name
+        ipath = ipath.parent
+    # Treat relative paths as relative to the platform's conventional location;
+    # however, if the path starts with an explicit references to the current
+    # working directory, use it as is.
+    if not ipath.is_absolute() and not config_string.startswith("./"):
+        # If the path includes a directory, use it the "application name";
+        # otherwise (in which case pathlib will report the parent as ".") use
+        # the default application name.
+        app_name = str(ipath) if str(ipath) != "." else APPLICATION_NAME
+        # noinspection PyArgumentList
+        platform_dir = get_platform_path(app_name, ensure_exists=True)
+        ipath = platform_dir / ipath
+    ipath /= filename if filename else default_file_name
+    return ipath

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 click~=8.1.0
+google-api-python-client~=2.159.0
+google-auth-oauthlib~=1.2.1
 playwright~=1.49.0
+platformdirs~=4.3.6
 PyMuPDF~=1.25.2
+protobuf~=5.29.3
 pyyaml~=6.0.2
 yattag~=1.16.1


### PR DESCRIPTION
This PR is the next iteration following #10:  this change adds functionality which takes the generated HTML and uploads it to Google Drive as a GDoc.

This change supports user configuration of
- the name of the file on the GDrive, including the ability to use a template to insert the current date/time;
- the name/path to the cached OAuth token file; and,
- the name/path to the file file containing the Google client app credentials.

In all cases, reasonable defaults are provided if no value is provided in the configuration.  By default, the token and credential files are stored in platform-conventional locations.  And, the default for the GDrive file is `Logilica_Reports_<date>`.

Things still missing:
- We need more testing.
- The reports are not filtered by their teams/repos.
- The images as rendered by Google are not good quality and are oddly cropped.
- The tool does not yet facilitate connecting the generated document to any other document.