### PR TITLE
HTML to GDoc, pass #2

### DIFF
--- a/logilica_weekly_report/cli_weekly_report.py
+++ b/logilica_weekly_report/cli_weekly_report.py
@@ -74,8 +74,10 @@ def weekly_report(
     configuration = context.obj["configuration"]
     logilica_credentials = context.obj["logilica_credentials"]
 
-    # Get the credentials now to enable "failing early".
-    google_credentials = get_google_credentials(configuration["config"])
+    # If needed, get the credentials now to enable "failing early".
+    google_credentials = (
+        get_google_credentials(configuration["config"]) if output == "gdoc" else None
+    )
 
     remove_downloads = not download_dir_path.exists()
     logging.debug(

--- a/logilica_weekly_report/cli_weekly_report.py
+++ b/logilica_weekly_report/cli_weekly_report.py
@@ -103,7 +103,10 @@ def weekly_report(
         )
         doc = generate_html(pdf_items)
         if output == "gdoc":
-            upload_doc(doc.getvalue(), google_credentials, configuration["config"])
+            url = upload_doc(
+                doc.getvalue(), google_credentials, configuration["config"]
+            )
+            click.echo(f"Report uploaded to {url}")
         else:
             click.echo(doc.getvalue(), err=False)
     except Exception as err:

--- a/logilica_weekly_report/cli_weekly_report.py
+++ b/logilica_weekly_report/cli_weekly_report.py
@@ -98,6 +98,7 @@ def weekly_report(
 
     try:
         if source == "logilica":
+            logging.info("Starting session")
             with PlaywrightSession() as page:
                 login_page = LoginPage(page=page, credentials=logilica_credentials)
                 login_page.navigate()

--- a/logilica_weekly_report/page_dashboard.py
+++ b/logilica_weekly_report/page_dashboard.py
@@ -36,7 +36,7 @@ class DashboardPage:
         for team, dashboards in teams.items():
             for dashboard, options in dashboards["team_dashboards"].items():
                 logging.debug(
-                    "Downloadining dashboard '%s / %s' for team '%s'",
+                    "Downloading dashboard '%s / %s' for team '%s'",
                     menu_dropdown,
                     dashboard,
                     team,
@@ -46,7 +46,8 @@ class DashboardPage:
                 )
                 self.download_dashboard_to(path=base_dir_path / options["Filename"])
             logging.info(
-                "Downloaded %d dashboard(s) for '%s' team",
+                "Downloaded %d dashboard%s for '%s' team",
                 len(dashboards["team_dashboards"]),
+                "s" if len(dashboards["team_dashboards"]) > 1 else "",
                 team,
             )

--- a/logilica_weekly_report/pdf_extract.py
+++ b/logilica_weekly_report/pdf_extract.py
@@ -11,11 +11,9 @@ import pymupdf
 # Choosing a higher image DPI produces a finer quality image but a larger
 # amount of data; it also affects the sizes of the headers and footers; so,
 # everything is parameterized by SCALE.
-SCALE = 20
-IMAGE_DPI = 30 * SCALE  # Resolution for images
-REPORT_HEADER_HEIGHT = 39 * SCALE + 4  # (256 + 134)@300dpi + fudge
-PAGE_HEADER_HEIGHT = 5 * SCALE
-PAGE_FOOTER_HEIGHT = 18 * SCALE
+REPORT_HEADER_HEIGHT = 94
+PAGE_HEADER_HEIGHT = 12
+PAGE_FOOTER_HEIGHT = 43
 
 
 def get_pdf_objects(
@@ -72,7 +70,7 @@ def get_report_image(pdf: pymupdf.Document) -> bytes:
     total_length = 0
     for i, page in enumerate(iter(pdf)):
         offset = REPORT_HEADER_HEIGHT if i == 0 else PAGE_HEADER_HEIGHT
-        pix: pymupdf.Pixmap = page.get_pixmap(dpi=IMAGE_DPI)
+        pix: pymupdf.Pixmap = page.get_pixmap()
         pl = strip_trailing_space(pix) - offset
         page_areas.append(PageArea(offset, pl, pix))
         total_length += pl
@@ -96,6 +94,15 @@ def get_report_image(pdf: pymupdf.Document) -> bytes:
         dest_rect = (0, dest_start, pix.width, dest_end)
         d_image.copy(pix, dest_rect)
         dest_start = dest_end
+
+    logging.debug(
+        "Resulting image size (%d dpi):  %d x %d (pixels);   %0.2f x %0.2f (inches)",
+        d_image.xres,
+        d_image.width,
+        d_image.height,
+        d_image.width / d_image.xres,
+        d_image.height / d_image.yres,
+    )
     return d_image.tobytes(output="png")
 
 

--- a/logilica_weekly_report/pdf_extract.py
+++ b/logilica_weekly_report/pdf_extract.py
@@ -75,6 +75,14 @@ def get_report_image(pdf: pymupdf.Document) -> bytes:
         page_areas.append(PageArea(offset, pl, pix))
         total_length += pl
 
+    # Google Docs have a maximum image size of 2500 pixels in either dimension,
+    # so, we need to resize the result accordingly.
+    if total_length > 2500:
+        logging.warning(
+            "Dashboard image height (%s pixels) exceeds the Google Docs limit of 2500",
+            total_length,
+        )
+
     # Create the target pixmap based on the characteristics of the first page
     # and the total length of all the pages.
     base_pixmap = page_areas[0].pixmap

--- a/logilica_weekly_report/update_gdoc.py
+++ b/logilica_weekly_report/update_gdoc.py
@@ -112,10 +112,16 @@ def get_google_credentials(config: dict[str, any]) -> Credentials:
     new token is written to the cache file before returning.
 
     The Google OAuth 2.0 Client "app" configuration is constructed from a local
-    credentials file (which can be downloaded from https://console.developers.google.com,
-    under "Credentials").  It is located using the default mechanisms (e.g., in
-    ${HOME}/.config/gcloud/application_default_credentials.json).  (Currently,
-    the scope of the authorization is limited to the Google Drive APIs.)
+    credentials file (which can be downloaded from the "Credentials" link in
+    the sidebar on https://console.developers.google.com).  (Currently, the
+    scope of the authorization is limited to the Google Drive APIs.)
+
+    The names and locations of the credentials files can be specified in the
+    tool configuration using the keys `token_file` and `app_credentials_file`
+    under "config" -> "google".  The defaults for the file names are defined
+    at the top of this file.  The default locations are conventional for the
+    platform where the tool is run (the user "cache directory" and the user
+    "config directory", respectively) -- see https://platformdirs.readthedocs.io/.
     """
     token_file = get_token_file(config)
     logging.debug("Google OAuth token file: %s", token_file)

--- a/logilica_weekly_report/update_gdoc.py
+++ b/logilica_weekly_report/update_gdoc.py
@@ -31,6 +31,10 @@ def generate_html(pdf_items: dict[str, dict[str, bytes]]) -> SimpleDoc:
             with tag("h1"):
                 text("Logilica Weekly Report")
             add_teams(pdf_items, doc, tag, text)
+
+            # Append something visible, so that GDocs doesn't truncate the
+            # last dashboard image.
+            doc.asis("<hr>")
     return doc
 
 

--- a/logilica_weekly_report/update_gdoc.py
+++ b/logilica_weekly_report/update_gdoc.py
@@ -81,8 +81,9 @@ def upload_doc(doc: str, creds: Credentials, config: dict[str, any]) -> str:
         "name": filename,
         "mimeType": "application/vnd.google-apps.document",
     }
+    logging.info("Uploading report to %s on Google Drive", filename)
     try:
-        service = build("drive", "v3", credentials=creds)
+        service = build("drive", "v3", credentials=creds, cache_discovery=False)
         media = MediaIoBaseUpload(
             BytesIO(doc.encode()), mimetype="text/html", resumable=True
         )
@@ -98,8 +99,8 @@ def upload_doc(doc: str, creds: Credentials, config: dict[str, any]) -> str:
         while response is None:
             status, response = request.next_chunk()
             if status:
-                print(f"Uploaded {int(status.progress() * 100)}%.")
-        logging.info(
+                logging.debug("Uploaded %d%%.", int(status.progress() * 100))
+        logging.debug(
             'File "%s" with ID "%s" has been uploaded.', filename, response.get("id")
         )
 

--- a/logilica_weekly_report/update_gdoc.py
+++ b/logilica_weekly_report/update_gdoc.py
@@ -107,7 +107,7 @@ def upload_doc(doc: str, creds: Credentials, config: dict[str, any]) -> str:
         logging.error("An error occurred uploading %s: %s", filename, error)
         raise
 
-    return f"https://docs.google.com/document/d/{response.get("id")}"
+    return f"https://docs.google.com/document/d/{response.get('id')}"
 
 
 def get_google_credentials(config: dict[str, any]) -> Credentials:

--- a/logilica_weekly_report/update_gdoc.py
+++ b/logilica_weekly_report/update_gdoc.py
@@ -68,6 +68,8 @@ def upload_doc(doc: str, creds: Credentials, config: dict[str, any]) -> str:
     The file is created on the Google Drive with a MIME type of
     `'application/vnd.google-apps.document'`, which causes Google to treat it
     as or convert it to a GDoc.
+
+    Returns the URL for the resulting GDoc.
     """
 
     filename = (
@@ -105,7 +107,7 @@ def upload_doc(doc: str, creds: Credentials, config: dict[str, any]) -> str:
         logging.error("An error occurred uploading %s: %s", filename, error)
         raise
 
-    return response.get("id")
+    return f"https://docs.google.com/document/d/{response.get("id")}"
 
 
 def get_google_credentials(config: dict[str, any]) -> Credentials:

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -26,7 +26,7 @@ class MyTestCase(unittest.TestCase):
             "Unexpected number of dashboards found.",
         )
         self.assertEqual(
-            1360589,
+            175526,
             len(result["Mock Team"]["Mock Team Dashboard"]),
             "Unexpected images size found.",
         )

--- a/tests/test_update_gdoc.py
+++ b/tests/test_update_gdoc.py
@@ -229,6 +229,7 @@ class TestUpdateGDoc(unittest.TestCase):
         mock_datetime,
     ):
         expected_id = "mock ID string"
+        expected_url = f"https://docs.google.com/document/d/{expected_id}"
         frozen_time = datetime.now(tz=timezone.utc)
 
         mock_doc = MagicMock()
@@ -248,7 +249,7 @@ class TestUpdateGDoc(unittest.TestCase):
         mock_datetime.now.return_value = frozen_time
 
         def check_result(expected_file_name, result_id):
-            self.assertEqual(expected_id, result_id)
+            self.assertEqual(expected_url, result_id)
             actual_file = handle_create.call_args.kwargs.get("body", {}).get("name")
             self.assertEqual(expected_file_name, actual_file)
             # Reset for next scenario
@@ -286,7 +287,7 @@ class TestUpdateGDoc(unittest.TestCase):
             (mock_status, mock_response),
         )
         result = upload_doc(mock_doc, mock_creds, {})
-        self.assertEqual(expected_id, result)
+        self.assertEqual(expected_url, result)
         # Reset for next scenario
         handle_create.reset_mock()
         mock_status.progress.reset_mock(side_effect=True)
@@ -299,7 +300,6 @@ class TestUpdateGDoc(unittest.TestCase):
         logging.getLogger().setLevel(logging.CRITICAL)  # Suppress the error message
         with self.assertRaises(HttpError):
             _ = upload_doc(mock_doc, mock_creds, {})
-        self.assertEqual(expected_id, result)
         handle_create.reset_mock()
         mock_status.progress.reset_mock(side_effect=True)
 

--- a/weekly_report.yaml
+++ b/weekly_report.yaml
@@ -16,4 +16,4 @@ teams:
         Filename: KUBESAW_Report.pdf
     jira_projects: issues.redhat.com/KUBESAW
 config:
-  # There are no tool configuration options, currently.
+  {}  # There are no tool configuration options, currently.

--- a/weekly_report.yaml
+++ b/weekly_report.yaml
@@ -15,5 +15,3 @@ teams:
       Sprint Planning Accuracy:
         Filename: KUBESAW_Report.pdf
     jira_projects: issues.redhat.com/KUBESAW
-config:
-  {}  # There are no tool configuration options, currently.


### PR DESCRIPTION
This is the next iteration on the Logilica Dashboard reporting tool, following #12.

With this change, the images as rendered by Google are no longer oddly cropped or scaled.  This change adds an "extra" _horizontal rule_ after the last image, which works around an apparent GDocs bug that results in the last page being shorter than the others and too short to contain the last dashboard image which causes the image to be cropped; adding the extra artifact results in an otherwise blank page at the end of the document, but that's better than missing half of the last dashboard.

The previous revision of the tool created the images at high resolution in an attempt to improve their quality.  Unfortunately, Google imposes a limit of 2500 pixels on images, rescaling them if they are over the limit.  Because each dashboard is a different length, rescaling each image to a length of 2500 pixels resulted in each image being a different width from the others, which caused the wider images to be cropped.  This PR uses the native resolution of the images from the PDF (72 DPI) which yields consistent image widths and lengths that are less than Google's limit; unfortunately, their overall quality seems to be slightly lower than the compound effects of the previous code, but Google seems to generally be happy with it (e.g., all the images come out with consistent treatment in the GDoc, which is presumably more important than their quality).

This PR also makes the tool print out the URL for the newly created GDoc, so that the user can readily copy-and-paste it into the main report.

In addition, this PR adds a number of quality-of-life improvements:
- When using the `--output` option to dump the result to a local HTML file instead of uploading it to Google, the tool skips fetching the Google credentials, allowing for local testing/use.
- Updates the docstring describing the Google credentials sourcing and use.
- The dashboard page pixmaps are now instantiated only once and cached.
- The tool will issue a warning if a dashboard image height exceeds Google's maximum, which hopefully will help allay future confusion.
- There is now an `--input` option to control the source of the PDF files -- if the files are available from a previous download, then they can be reused instead of having to re-download them on every run.  (This is very handy for testing locally.)
- Found and removed a bogus unit test assertion.
- Corrected the configuration file -- with the new schema validation, it wasn't specifying an empty `"config"` section properly.
- And, tweaked the logging to make the `-v` and `-vv` outputs better.

There is still one outstanding item to be address in a subsequent PR:  the reports are not filtered by their teams/repos, so they contain data from _all_ projects/repos.
