### PR TITLE
Use filters when generating reports

### DIFF
--- a/logilica_weekly_report/cli_data_sources.py
+++ b/logilica_weekly_report/cli_data_sources.py
@@ -55,7 +55,7 @@ def data_sources(
             settings_page.sync_integrations(integrations=configuration["integrations"])
 
     except Exception as err:
-        click.echo(err, err=True)
+        click.echo(f"Unexpected exception, {type(err).__name__}: {err}", err=True)
         exit_status = 1
 
     context.exit(exit_status)

--- a/logilica_weekly_report/cli_weekly_report.py
+++ b/logilica_weekly_report/cli_weekly_report.py
@@ -70,15 +70,12 @@ def weekly_report(
         team_dashboards:
           Board 1:
             filename: board1_report.pdf
-            filter:
-              Selector1: ["s1val1"]
-              Selector2: ["s2val1", "s2val2"]
+            url: some-string
       Team 2:
         team_dashboards:
           Board 1:
             filename: board2_report.pdf
-            filter:
-              Selector3: ["s3val1", "s3val2"]
+            url: some-string
         ...
     ...
     """

--- a/logilica_weekly_report/cli_weekly_report.py
+++ b/logilica_weekly_report/cli_weekly_report.py
@@ -69,14 +69,14 @@ def weekly_report(
       Team 1:
         team_dashboards:
           Board 1:
-            Filename: board1_report.pdf
+            filename: board1_report.pdf
             filter:
               Selector1: ["s1val1"]
               Selector2: ["s2val1", "s2val2"]
       Team 2:
         team_dashboards:
           Board 1:
-            Filename: board2_report.pdf
+            filename: board2_report.pdf
             filter:
               Selector3: ["s3val1", "s3val2"]
         ...
@@ -124,7 +124,7 @@ def weekly_report(
         else:
             click.echo(doc.getvalue(), err=False)
     except Exception as err:
-        click.echo(err, err=True)
+        click.echo(f"Unexpected exception, {type(err).__name__}: {err}", err=True)
         exit_status = 1
     finally:
         if remove_downloads:

--- a/logilica_weekly_report/cli_weekly_report.py
+++ b/logilica_weekly_report/cli_weekly_report.py
@@ -70,12 +70,15 @@ def weekly_report(
         team_dashboards:
           Board 1:
             Filename: board1_report.pdf
-        jira_projects: issues.redhat.com/FOO
+            filter:
+              Selector1: ["s1val1"]
+              Selector2: ["s2val1", "s2val2"]
       Team 2:
         team_dashboards:
           Board 1:
             Filename: board2_report.pdf
-        jira_projects: issues.redhat.com/BAR
+            filter:
+              Selector3: ["s3val1", "s3val2"]
         ...
     ...
     """

--- a/logilica_weekly_report/configuration_schema.py
+++ b/logilica_weekly_report/configuration_schema.py
@@ -16,7 +16,7 @@ schema = {
                         "additionalProperties": {
                             "type": "object",
                             "properties": {
-                                "Filename": {"type": "string"},
+                                "filename": {"type": "string"},
                                 "filter": {
                                     "type": "object",
                                     "additionalProperties": {

--- a/logilica_weekly_report/configuration_schema.py
+++ b/logilica_weekly_report/configuration_schema.py
@@ -15,10 +15,18 @@ schema = {
                         "type": "object",
                         "additionalProperties": {
                             "type": "object",
-                            "properties": {"Filename": {"type": "string"}},
+                            "properties": {
+                                "Filename": {"type": "string"},
+                                "filter": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                },
+                            },
                         },
                     },
-                    "jira_projects": {"type": "string"},
                 },
             },
         },

--- a/logilica_weekly_report/configuration_schema.py
+++ b/logilica_weekly_report/configuration_schema.py
@@ -19,9 +19,13 @@ schema = {
                                 "filename": {"type": "string"},
                                 "url": {"type": "string"},
                             },
+                            "required": ["filename", "url"],
+                            "additionalProperties": False,
                         },
                     },
                 },
+                "required": ["team_dashboards"],
+                "additionalProperties": False,
             },
         },
         "integrations": {
@@ -41,6 +45,8 @@ schema = {
                         "optional": True,
                     },
                 },
+                "required": ["connector"],
+                "additionalProperties": False,
             },
         },
         "config": {
@@ -58,10 +64,13 @@ schema = {
                             "description": "Path to the Google OAuth token file",
                         },
                     },
+                    "additionalProperties": False,
                 },
             },
+            "additionalProperties": False,
         },
     },
+    "additionalProperties": False,
 }
 
 

--- a/logilica_weekly_report/configuration_schema.py
+++ b/logilica_weekly_report/configuration_schema.py
@@ -17,13 +17,7 @@ schema = {
                             "type": "object",
                             "properties": {
                                 "filename": {"type": "string"},
-                                "filter": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                        "type": "array",
-                                        "items": {"type": "string"},
-                                    },
-                                },
+                                "url": {"type": "string"},
                             },
                         },
                     },

--- a/logilica_weekly_report/configuration_schema.py
+++ b/logilica_weekly_report/configuration_schema.py
@@ -37,12 +37,10 @@ schema = {
                     "public_repositories": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "optional": True,
                     },
                     "membership_repositories": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "optional": True,
                     },
                 },
                 "required": ["connector"],

--- a/logilica_weekly_report/page_dashboard.py
+++ b/logilica_weekly_report/page_dashboard.py
@@ -2,13 +2,13 @@ import logging
 import pathlib
 from typing import Any
 
-from playwright.sync_api import Page
+from playwright.sync_api import expect, Page
 
 from logilica_weekly_report.page_navigation import NavigationPanel
 
 
 class DashboardPage:
-    TIMEOUT = 3000
+    LOAD_TIMEOUT = 30000
 
     def __init__(self, page: Page):
         self.page = page
@@ -31,7 +31,7 @@ class DashboardPage:
         teams: dict[str, Any],
         base_dir_path: pathlib.Path,
         *,
-        menu_dropdown="Custom Reports"
+        menu_dropdown="Custom Reports",
     ) -> None:
         for team, dashboards in teams.items():
             for dashboard, options in dashboards["team_dashboards"].items():
@@ -44,7 +44,33 @@ class DashboardPage:
                 NavigationPanel(self.page).navigate(
                     link_name=dashboard, menu_dropdown=menu_dropdown
                 )
+                expect(self.export_pdf_button).to_be_visible(
+                    timeout=DashboardPage.LOAD_TIMEOUT
+                )
+
+                if filters := options.get("filter"):
+                    for filter_, values in filters.items():
+                        controls = self.page.locator("css=.css-qmtbtl-control")
+                        controls.get_by_text(filter_, exact=True).click()
+                        for value in values:
+                            loc = self.page.locator("css=.flex.p-2.cursor-pointer")
+                            loc.get_by_text(value).click()
+                        self.page.get_by_role("button", name="Apply").click()
+
                 self.download_dashboard_to(path=base_dir_path / options["Filename"])
+
+                if filters:
+                    # Clear all the filters
+                    clicked = 0
+                    controls = self.page.locator("css=.my-auto.cursor-pointer")
+                    for control in controls.all():
+                        if control.is_visible():
+                            control.click()
+                            clicked += 1
+                    if clicked != len(filters):
+                        logging.warning(
+                            "Cleared %d filters but set %d", clicked, len(filters)
+                        )
             logging.info(
                 "Downloaded %d dashboard%s for '%s' team",
                 len(dashboards["team_dashboards"]),

--- a/logilica_weekly_report/page_dashboard.py
+++ b/logilica_weekly_report/page_dashboard.py
@@ -57,7 +57,7 @@ class DashboardPage:
                             loc.get_by_text(value).click()
                         self.page.get_by_role("button", name="Apply").click()
 
-                self.download_dashboard_to(path=base_dir_path / options["Filename"])
+                self.download_dashboard_to(path=base_dir_path / options["filename"])
 
                 if filters:
                     # Clear all the filters

--- a/logilica_weekly_report/page_dashboard.py
+++ b/logilica_weekly_report/page_dashboard.py
@@ -2,14 +2,10 @@ import logging
 import pathlib
 from typing import Any
 
-from playwright.sync_api import expect, Page
-
-from logilica_weekly_report.page_navigation import NavigationPanel
+from playwright.sync_api import Page
 
 
 class DashboardPage:
-    LOAD_TIMEOUT = 30000
-
     def __init__(self, page: Page):
         self.page = page
         self.export_pdf_button = page.get_by_role("button", name="Export PDF")
@@ -41,36 +37,9 @@ class DashboardPage:
                     dashboard,
                     team,
                 )
-                NavigationPanel(self.page).navigate(
-                    link_name=dashboard, menu_dropdown=menu_dropdown
-                )
-                expect(self.export_pdf_button).to_be_visible(
-                    timeout=DashboardPage.LOAD_TIMEOUT
-                )
-
-                if filters := options.get("filter"):
-                    for filter_, values in filters.items():
-                        controls = self.page.locator("css=.css-qmtbtl-control")
-                        controls.get_by_text(filter_, exact=True).click()
-                        for value in values:
-                            loc = self.page.locator("css=.flex.p-2.cursor-pointer")
-                            loc.get_by_text(value).click()
-                        self.page.get_by_role("button", name="Apply").click()
-
+                self.page.goto(url=options["url"])
                 self.download_dashboard_to(path=base_dir_path / options["filename"])
 
-                if filters:
-                    # Clear all the filters
-                    clicked = 0
-                    controls = self.page.locator("css=.my-auto.cursor-pointer")
-                    for control in controls.all():
-                        if control.is_visible():
-                            control.click()
-                            clicked += 1
-                    if clicked != len(filters):
-                        logging.warning(
-                            "Cleared %d filters but set %d", clicked, len(filters)
-                        )
             logging.info(
                 "Downloaded %d dashboard%s for '%s' team",
                 len(dashboards["team_dashboards"]),

--- a/logilica_weekly_report/page_settings.py
+++ b/logilica_weekly_report/page_settings.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import logging
-from typing import Any, Generator, Tuple, TypeAlias
+from typing import Any, Generator, Optional, Tuple, TypeAlias
 
 from playwright.sync_api import expect, Locator, Page
 
@@ -30,7 +30,7 @@ class SettingsPage:
         self.search_imported_repos_field = page.locator(
             "input[placeholder='Search repository...']"
         ).nth(0)
-        self.search_availaible_repos_field = page.locator(
+        self.search_available_repos_field = page.locator(
             "input[placeholder='Search repository...']"
         ).nth(1)
         self.add_public_repository_input = page.locator(
@@ -59,7 +59,7 @@ class SettingsPage:
         repositories: list[str],
     ) -> Generator[str, None, None]:
         """Waits for Integration / Settings / Available Repositories and
-        aftewards yields the list of repositories.
+        afterwards yields the list of repositories.
         """
         if repositories:
             logging.debug(
@@ -234,7 +234,7 @@ class SettingsPage:
         """Adds repository as membership repository."""
 
         logging.debug("⏳ Adding membership repository '%s'", repository_slug)
-        self.search_availaible_repos_field.fill(repository_slug)
+        self.search_available_repos_field.fill(repository_slug)
         locator = self.repository_control_button(repository_slug, order=1)
         if locator:
             locator.click()
@@ -243,17 +243,22 @@ class SettingsPage:
 
         return False
 
-    def repository_control_button(self, repository_slug: str, *, order=0) -> Locator:
+    def repository_control_button(
+        self, repository_slug: str, *, order=0
+    ) -> Optional[Locator]:
         """Finds repository control button.
 
-        Finds repository control button. Since there might be multiple buttons (up to 2), provides additional logic to pickup the right one.
-        The first button might be found in imported repositories, the other one in available repositories.
+        Finds repository control button. Since there might be multiple buttons
+        (up to 2), provides additional logic to pick up the right one.  The
+        first button might be found in imported repositories, the other one in
+        available repositories.
 
         Args:
           repository_slug:
             git slug that identifies the repository, e.g. org_name/repo_name
           order: optional
-            identifies what button is returned if 2 are found (by default the first one, indexed from 0)
+            identifies what button is returned if 2 are found (by default the
+            first one, indexed from 0)
 
         Returns:
           Control button.
@@ -287,8 +292,8 @@ class SettingsPage:
     def repository_slug_locator(self, slug: str) -> Locator:
         """Locator for repository slug element."""
 
-        # here we need to find the innnermost div element that exactly matches repository slug
-        # alternative option is to use an xpath selector that is more powerfull. Leaving it
+        # here we need to find the innermost div element that exactly matches repository slug
+        # alternative option is to use an xpath selector that is more powerful. Leaving it
         # in the code in case it will be needed because of DOM tree changes
         # self.page.locator(f"//div[normalize-space()='{slug}' and not(descendant::div)]")
         return self.page.get_by_text(text=slug, exact=True)

--- a/logilica_weekly_report/pdf_extract.py
+++ b/logilica_weekly_report/pdf_extract.py
@@ -28,9 +28,9 @@ def get_pdf_objects(
         Practices Team:
           team_dashboards:
             Developer Practices Dashboard:
-              Filename: DPROD_Report.pdf
+              filename: DPROD_Report.pdf
             DPROD Dashboard 2:
-              Filename: DPROD_Report2.pdf
+              filename: DPROD_Report2.pdf
             ...
         ...
 
@@ -45,7 +45,7 @@ def get_pdf_objects(
         for dashboard, options in dashboards["team_dashboards"].items():
             logging.info("Extracting items from '%s' for %s", dashboard, team)
             pdf: pymupdf.Document
-            with pymupdf.open(download_dir_path / options["Filename"]) as pdf:
+            with pymupdf.open(download_dir_path / options["filename"]) as pdf:
                 team_results[dashboard] = get_report_image(pdf)
         results[team] = team_results
     return results

--- a/logilica_weekly_report/playwright_session.py
+++ b/logilica_weekly_report/playwright_session.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from playwright.sync_api import BrowserContext, Page, sync_playwright
 
 
@@ -7,8 +9,8 @@ class PlaywrightSession:
     def __init__(self, headless=True):
         self.headless = headless
         self.browser = None
-        self.context: BrowserContext = None
-        self.page: Page = None
+        self.context: Optional[BrowserContext] = None
+        self.page: Optional[Page] = None
 
     def __enter__(self):
         self.playwright = sync_playwright().start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,10 @@
 click~=8.1.0
-google-api-core~=2.24.1
-google-api-python-client~=2.160.0
-google-auth~=2.38.0
-google-auth-httplib2~=0.2.0
+google-api-python-client~=2.159.0
 google-auth-oauthlib~=1.2.1
-googleapis-common-protos~=1.66.0
-playwright~=1.49.0
 platformdirs~=4.3.6
-PyMuPDF~=1.25.2
+playwright~=1.49.0
 protobuf~=5.29.3
+PyMuPDF~=1.25.2
 pyyaml~=6.0.2
 yattag~=1.16.1
 jsonschema~=4.23.0

--- a/tests/test_configuration_schema.py
+++ b/tests/test_configuration_schema.py
@@ -12,7 +12,7 @@ teams:
   My Awesome Team:
     team_dashboards:
       Team Productivity Dashboard:
-        Filename: Awesome.pdf
+        filename: Awesome.pdf
         filter:
           Selector1: ["s1val1"]
           Selector2: ["s2val1", "s2val2"]
@@ -36,7 +36,7 @@ teams:
   My Awesome Team:
     team_dashboards:
       Team Productivity Dashboard:
-        Filename: Awesome.pdf
+        filename: Awesome.pdf
 integrations:
   foobar-public-bot:
     connector: GitHub
@@ -57,7 +57,7 @@ teams:
   My Awesome Team:
     team_dashboards:
       Team Productivity Dashboard:
-        Filename: 1
+        filename: 1
         filter:
           Selector1: [1]
           Selector2: ["s2val1", 2]

--- a/tests/test_configuration_schema.py
+++ b/tests/test_configuration_schema.py
@@ -1,4 +1,6 @@
+from copy import deepcopy
 from io import StringIO
+from typing import Any, Generator
 import unittest
 
 from jsonschema import ValidationError
@@ -6,8 +8,9 @@ import yaml
 
 from logilica_weekly_report.configuration_schema import validate_configuration
 
-VALID_CONFIGS = (
-    """---
+FULL_CONFIG = yaml.safe_load(
+    StringIO(
+        """---
 teams:
   My Awesome Team:
     team_dashboards:
@@ -18,8 +21,10 @@ integrations:
   foobar-bot:
     connector: GitHub
     membership_repositories:
-      - myorg/my-repo
-      - myorg/my-repo-2
+      - my_org/my-repo
+      - my_org/my-repo-2
+    public_repositories:
+      - my-public-org/my-repo
   foobar-public-bot:
     connector: GitHub
     public_repositories:
@@ -28,78 +33,369 @@ config:
   google:
     app_credentials_file: path/to/file
     token_file: path/to/file
-""",
-    """---
-teams:
-  My Awesome Team:
-    team_dashboards:
-      Team Productivity Dashboard:
-        filename: Awesome.pdf
-        url: some-string
-integrations:
-  foobar-public-bot:
-    connector: GitHub
-    public_repositories:
-      - my-public-org/my-repo
-""",
-    """---
-config:
-  google:
-    app_credentials_file: path/to/file
-    token_file: path/to/file
-""",
+"""
+    )
 )
 
-INVALID_CONFIGS = (
-    """---
-teams:
-  My Awesome Team:
-    team_dashboards:
-      Team Productivity Dashboard:
-        filename: 1
-        not-url: some-string
-integrations:
-  foobar-bot:
-    connector: GitHub
-    membership_repositories:
-      - 2
-      - myorg/my-repo-2
-  foobar-public-bot:
-    connector: GitHub
-    public_repositories:
-      - my-public-org/my-repo
-config:
-  google:
-    app_credentials_file: path/to/file
-    token_file: True
-""",
-    """---
-integrations:
-  foobar-public-bot:
-    connector: GitHub
-    public_repositories:
-      - 2
-""",
-    """---
-config:
-  google:
-    app_credentials_file: path/to/file
-    token_file: 42
-""",
-)
+
+def recursive_descent_removal(
+    removals: dict[str, Any],
+    cfg: dict[str, Any],
+    original_config: dict[str, Any],
+    mkey: str,
+) -> Generator[dict[str, Any], None, None]:
+    """Recursively descend the tree of missing fields, removing them from the
+    configuration where indicated, yielding the result, and then restoring them
+    again.
+
+    `cfg` must refer to a subtree of `original_config`, so that when `cfg` is
+    modified, the result appears in `original_config`.
+    """
+    for k, v in removals.items():
+        if k == mkey:
+            continue
+
+        if k not in cfg:
+            raise AssertionError(
+                f"Test bug: key {k!s} not found in {cfg} inside {original_config}"
+            )
+
+        if mkey in v:
+            save = cfg[k]
+            del cfg[k]
+            yield original_config
+            cfg[k] = save
+
+        yield from recursive_descent_removal(v, cfg[k], original_config, mkey)
+
+
+def generate_valid_configs() -> Generator[dict[str, Any], None, None]:
+    """A generator which yields a sequence of valid configurations."""
+    # Exactly one root-level key present.
+    for k, v in FULL_CONFIG.items():
+        yield {k: v}
+
+    # Exactly one root-level key absent from the full configuration, or one
+    # missing optional field.
+    mkey = "remove_this_key"
+    missing = {
+        "teams": {mkey: True},
+        "integrations": {
+            mkey: True,
+            next(iter(FULL_CONFIG["integrations"])): {
+                "public_repositories": {mkey: True},
+                "membership_repositories": {mkey: True},
+            },
+        },
+        "config": {
+            mkey: True,
+            "google": {
+                "app_credentials_file": {mkey: True},
+                "token_file": {mkey: True},
+            },
+        },
+    }
+
+    # Create a copy of the configuration which the subroutine will modify and
+    # yield.
+    config = deepcopy(FULL_CONFIG)
+    yield from recursive_descent_removal(missing, config, config, mkey)
+    assert config == deepcopy(FULL_CONFIG)  # Make sure we cleaned up properly.
+
+
+def recursive_descent_add(
+    extra: dict[str, Any],
+    cfg: dict[str, Any],
+    original_config: dict[str, Any],
+    e_key: str,
+) -> Generator[dict[str, Any], None, None]:
+    """Recursively descend the tree of extraneous fields, adding them to the
+    configuration where indicated, yielding the result, and then removing them
+    again.
+
+    `cfg` must refer to a subtree of `original_config`, so that when `cfg` is
+    modified, the result appears in `original_config`.
+    """
+    for k, v in extra.items():
+        if k == e_key:
+            cfg[k] = v
+            yield original_config
+            del cfg[k]
+        elif k in cfg:
+            yield from recursive_descent_add(v, cfg[k], original_config, e_key)
+        else:
+            raise AssertionError(
+                f"Test bug: key {k!s} not found in {cfg} inside {original_config}"
+            )
+
+
+def generate_extraneous_keys() -> Generator[dict[str, Any], None, None]:
+    """A generator which yields a sequence of configurations which are invalid
+    because they contain extraneous fields where they are not permitted.
+    """
+
+    # This config tree mirrors the structure of the full config tree with extra
+    # fields added in places where they are not permitted; the test will
+    # generate configurations by adding single fields from this tree to the
+    # full configuration.  These are the locations of the extra fields:
+    #   - root-level key
+    #   - under "teams.XXX"
+    #   - under "teams.XXX.team_dashboards.YYY"
+    #   - under "integrations.XXX"
+    #   - under "config"
+    #   - under "config.google"
+    first_team = next(iter(FULL_CONFIG["teams"]))
+    first_dashboard = next(iter(FULL_CONFIG["teams"][first_team]["team_dashboards"]))
+    e_key = "extraneous_key"
+    extraneous = {
+        e_key: "extraneous_value",
+        "teams": {
+            first_team: {
+                e_key: "extraneous_value",
+                "team_dashboards": {first_dashboard: {e_key: "extraneous_value"}},
+            }
+        },
+        "integrations": {
+            next(iter(FULL_CONFIG["integrations"])): {e_key: "extraneous_value"}
+        },
+        "config": {e_key: "extraneous_value", "google": {e_key: "extraneous_value"}},
+    }
+
+    # Create a copy of the configuration which the inner function will modify
+    # and yield.
+    config = deepcopy(FULL_CONFIG)
+    yield from recursive_descent_add(extraneous, config, config, e_key)
+    assert config == deepcopy(FULL_CONFIG)  # Make sure we cleaned up properly.
+
+
+def generate_missing_fields() -> Generator[dict[str, Any], None, None]:
+    """A generator which yields a sequence of configurations which are invalid
+    because they are missing required fields.
+    """
+
+    # This config tree mirrors the structure of the full config tree with
+    # markers added to indicate fields which should be removed for testing; the
+    # test will generate configurations by removing the indicated fields from
+    # the full configuration.  These are the locations of the fields:
+    #   - "teams.XXX.team_dashboards"
+    #   - "teams.XXX.team_dashboards.YYY.filename"
+    #   - "teams.XXX.team_dashboards.YYY.url"
+    #   - "integrations.XXX.connector"
+    first_team = next(iter(FULL_CONFIG["teams"]))
+    first_dashboard = next(iter(FULL_CONFIG["teams"][first_team]["team_dashboards"]))
+    mkey = "remove_this_key"
+    missing = {
+        "teams": {
+            first_team: {
+                "team_dashboards": {
+                    mkey: True,
+                    first_dashboard: {
+                        "filename": {mkey: True},
+                        "url": {mkey: True},
+                    },
+                }
+            }
+        },
+        "integrations": {
+            next(iter(FULL_CONFIG["integrations"])): {"connector": {mkey: True}}
+        },
+    }
+
+    # Create a copy of the configuration which the subroutine will modify and
+    # yield.
+    config = deepcopy(FULL_CONFIG)
+    yield from recursive_descent_removal(missing, config, config, mkey)
+    assert config == deepcopy(FULL_CONFIG)  # Make sure we cleaned up properly.
+
+
+def recursive_descent_replacement(
+    mods: dict[str, Any],
+    cfg: dict[str, Any],
+    original_config: dict[str, Any],
+    r_key: str,
+) -> Generator[dict[str, Any], None, None]:
+    """Recursively descend the tree of to-be-replaced fields, replacing their
+    values where indicated in the configuration, yielding the result, and then
+    restoring them again.
+
+    `cfg` must refer to a subtree of `original_config`, so that when `cfg` is
+    modified, the result appears in `original_config`.
+    """
+    for k, v in mods.items():
+        if k == r_key:
+            continue
+
+        if k not in cfg:
+            raise AssertionError(
+                f"Test bug: key {k!s} not found in {cfg} inside {original_config}"
+            )
+
+        if r_key in v:
+            save = cfg[k]
+            cfg[k] = v[r_key]
+            yield original_config
+            cfg[k] = save
+
+        yield from recursive_descent_replacement(v, cfg[k], original_config, r_key)
+
+
+def generate_questionable_configs() -> Generator[dict[str, Any], None, None]:
+    """A generator which yields a sequence of configurations which are have
+    questionable validity because one of their fields is present but contains
+    an empty value.
+    """
+
+    # This config tree mirrors the structure of the full config tree with
+    # markers for fields whose values should be replaced in the config for
+    # testing; the test will generate configurations by replacing the indicated
+    # fields' values with the specified values in the full configuration, then
+    # the values will be restored for the next generation.  These are the
+    # locations of the fields:
+    #   - "teams", "integrations", "config" present with no (i.e., empty) value
+    #   - "teams.XXX.team_dashboards" present with no (i.e., empty) value
+    #   - "integrations.XXX.public_repositories" present with no (i.e., empty) value
+    #   - "integrations.XXX.membership_repositories" present with no (i.e., empty) value
+    #   - "config.google" present with no (i.e., empty) value
+
+    first_team = next(iter(FULL_CONFIG["teams"]))
+    first_integration = next(iter(FULL_CONFIG["integrations"]))
+    q_key = "replace_this_value"
+    replacements = {
+        "teams": {
+            q_key: {},
+            first_team: {"team_dashboards": {q_key: {}}},
+        },
+        "integrations": {
+            q_key: {},
+            first_integration: {
+                "public_repositories": {q_key: []},
+                "membership_repositories": {q_key: []},
+            },
+        },
+        "config": {
+            q_key: {},
+            "google": {q_key: {}},
+        },
+    }
+
+    # Create a copy of the configuration which the subroutine will modify and
+    # yield.
+    config = deepcopy(FULL_CONFIG)
+    yield from recursive_descent_replacement(replacements, config, config, q_key)
+    assert config == deepcopy(FULL_CONFIG)  # Make sure we cleaned up properly.
+
+
+def generate_bad_types() -> Generator[dict[str, Any], None, None]:
+    """A generator which yields a sequence of configurations which are invalid
+    because one of their fields contains the wrong type of data.
+    """
+
+    # This config tree mirrors the structure of the full config tree with
+    # markers for fields whose values should be replaced in the config for
+    # testing; the test will generate configurations by replacing the indicated
+    # fields' values with the specified values in the full configuration, then
+    # the values will be restored for the next generation.  These are the
+    # locations of the fields:
+    #   - "teams"
+    #   - "teams.XXX"
+    #   - "teams.XXX.team_dashboards"
+    #   - "teams.XXX.team_dashboards.YYY"
+    #   - "teams.XXX.team_dashboards.YYY.filename"
+    #   - "teams.XXX.team_dashboards.YYY.url"
+    #   - "integrations"
+    #   - "integrations.XXX"
+    #   - "integrations.XXX.connector"
+    #   - "integrations.XXX.public_repositories"
+    #   - "integrations.XXX.membership_repositories"
+    #   - "config"
+    #   - "config.google"
+    #   - "config.google.app_credentials_file"
+    #   - "config.google.token_file"
+    first_team = next(iter(FULL_CONFIG["teams"]))
+    first_dashboard = next(iter(FULL_CONFIG["teams"][first_team]["team_dashboards"]))
+    first_integration = next(iter(FULL_CONFIG["integrations"]))
+    b_key = "replace_this_value"
+    replacements = {
+        "teams": {
+            b_key: 1,
+            first_team: {
+                b_key: 1,
+                "team_dashboards": {
+                    b_key: 1,
+                    first_dashboard: {
+                        b_key: 1,
+                        "filename": {b_key: 1},
+                        "url": {b_key: 1},
+                    },
+                },
+            },
+        },
+        "integrations": {
+            b_key: 1,
+            first_integration: {
+                b_key: 1,
+                "connector": {b_key: 1},
+                "public_repositories": {b_key: 1},
+                "membership_repositories": {b_key: 1},
+            },
+        },
+        "config": {
+            b_key: 1,
+            "google": {
+                b_key: 1,
+                "app_credentials_file": {b_key: 1},
+                "token_file": {b_key: 1},
+            },
+        },
+    }
+
+    # Create a copy of the configuration which the subroutine will modify and
+    # yield.
+    config = deepcopy(FULL_CONFIG)
+    yield from recursive_descent_replacement(replacements, config, config, b_key)
+    assert config == deepcopy(FULL_CONFIG)  # Make sure we cleaned up properly.
 
 
 class TestConfigurationSchema(unittest.TestCase):
+
     def test_valid_configurations(self):
-        for entry in VALID_CONFIGS:
-            config = yaml.safe_load(StringIO(entry))
-            validate_configuration(config)
+        count = 0
+
+        def do_it(gen):
+            nonlocal count
+            for config in gen:
+                validate_configuration(config)
+                count += 1
+
+        do_it(generate_valid_configs())
+        self.assertEqual(10, count)
+        do_it(generate_questionable_configs())
+        self.assertEqual(10 + 7, count)
 
     def test_invalid_configurations(self):
-        for entry in INVALID_CONFIGS:
-            config = yaml.safe_load(StringIO(entry))
-            with self.assertRaises(ValidationError):
-                validate_configuration(config)
+        count = 0
+
+        def do_it(gen, exp):
+            nonlocal count
+            for config in gen:
+                with self.assertRaises(ValidationError) as cm:
+                    validate_configuration(config)
+                self.assertIn(exp, str(cm.exception))
+                count += 1
+
+        do_it(
+            generate_extraneous_keys(),
+            "Additional properties are not allowed ('extraneous_key' was unexpected)",
+        )
+        do_it(
+            generate_missing_fields(),
+            "is a required property",
+        )
+        do_it(
+            generate_bad_types(),
+            "is not of type",
+        )
+        self.assertEqual(25, count)
 
 
 if __name__ == "__main__":

--- a/tests/test_configuration_schema.py
+++ b/tests/test_configuration_schema.py
@@ -13,7 +13,9 @@ teams:
     team_dashboards:
       Team Productivity Dashboard:
         Filename: Awesome.pdf
-    jira_projects: issues.redhat.com/TEST
+        filter:
+          Selector1: ["s1val1"]
+          Selector2: ["s2val1", "s2val2"]
 integrations:
   foobar-bot:
     connector: GitHub
@@ -35,7 +37,6 @@ teams:
     team_dashboards:
       Team Productivity Dashboard:
         Filename: Awesome.pdf
-    jira_projects: issues.redhat.com/TEST
 integrations:
   foobar-public-bot:
     connector: GitHub
@@ -57,7 +58,9 @@ teams:
     team_dashboards:
       Team Productivity Dashboard:
         Filename: 1
-    jira_projects: issues.redhat.com/TEST
+        filter:
+          Selector1: [1]
+          Selector2: ["s2val1", 2]
 integrations:
   foobar-bot:
     connector: GitHub

--- a/tests/test_configuration_schema.py
+++ b/tests/test_configuration_schema.py
@@ -13,9 +13,7 @@ teams:
     team_dashboards:
       Team Productivity Dashboard:
         filename: Awesome.pdf
-        filter:
-          Selector1: ["s1val1"]
-          Selector2: ["s2val1", "s2val2"]
+        url: some-string
 integrations:
   foobar-bot:
     connector: GitHub
@@ -37,6 +35,7 @@ teams:
     team_dashboards:
       Team Productivity Dashboard:
         filename: Awesome.pdf
+        url: some-string
 integrations:
   foobar-public-bot:
     connector: GitHub
@@ -58,9 +57,7 @@ teams:
     team_dashboards:
       Team Productivity Dashboard:
         filename: 1
-        filter:
-          Selector1: [1]
-          Selector2: ["s2val1", 2]
+        not-url: some-string
 integrations:
   foobar-bot:
     connector: GitHub

--- a/tests/test_pdf_extract.py
+++ b/tests/test_pdf_extract.py
@@ -9,7 +9,7 @@ class MyTestCase(unittest.TestCase):
         config = {
             "Mock Team": {
                 "team_dashboards": {
-                    "Mock Team Dashboard": {"Filename": "sample_report.pdf"}
+                    "Mock Team Dashboard": {"filename": "sample_report.pdf"}
                 }
             }
         }

--- a/weekly_report.yaml
+++ b/weekly_report.yaml
@@ -1,17 +1,19 @@
 ---
 teams:
   Practices Team:
-    team_dashboards: 
-      Developer Practices Dashboard: 
+    team_dashboards:
+      Developer Practices Dashboard:
         Filename: DPROD_Report.pdf
-    jira_projects: issues.redhat.com/DPROD
   Sandbox Team:
     team_dashboards:
       Red Hat Outcomes:
         Filename: SANDBOX_Report.pdf
-    jira_projects: issues.redhat.com/SANDBOX    
+        filter:
+          Teams: ["Sandbox Team"]
+          Boards: ["SANDBOX-issues.redhat.com"]
   Kubesaw Team:
     team_dashboards:
       Sprint Planning Accuracy:
         Filename: KUBESAW_Report.pdf
-    jira_projects: issues.redhat.com/KUBESAW
+        filter:
+          "Jira Project Names": ["issues.redhat.com/SANDBOX"]

--- a/weekly_report.yaml
+++ b/weekly_report.yaml
@@ -3,17 +3,17 @@ teams:
   Practices Team:
     team_dashboards:
       Developer Practices Dashboard:
-        Filename: DPROD_Report.pdf
+        filename: DPROD_Report.pdf
   Sandbox Team:
     team_dashboards:
       Red Hat Outcomes:
-        Filename: SANDBOX_Report.pdf
+        filename: SANDBOX_Report.pdf
         filter:
           Teams: ["Sandbox Team"]
           Boards: ["SANDBOX-issues.redhat.com"]
   Kubesaw Team:
     team_dashboards:
       Sprint Planning Accuracy:
-        Filename: KUBESAW_Report.pdf
+        filename: KUBESAW_Report.pdf
         filter:
           "Jira Project Names": ["issues.redhat.com/SANDBOX"]

--- a/weekly_report.yaml
+++ b/weekly_report.yaml
@@ -4,16 +4,14 @@ teams:
     team_dashboards:
       Developer Practices Dashboard:
         filename: DPROD_Report.pdf
+        url: https://logilica.io/dashboard/023e570d-1398-458b-88e2-2c83ac6ad5c6?variables=W3sidmFyIjoiVGltZSIsInZhbCI6eyJkaW1lbnNpb24iOiJUaW1lIiwiZGF0ZVJhbmdlIjoiZnJvbSA5MCBkYXlzIGFnbyB0byBub3cifX1d&workstream=00000000b5cc5d88
   Sandbox Team:
     team_dashboards:
       Red Hat Outcomes:
         filename: SANDBOX_Report.pdf
-        filter:
-          Teams: ["Sandbox Team"]
-          Boards: ["SANDBOX-issues.redhat.com"]
+        url: https://logilica.io/dashboard/c2205e85-034e-4209-b218-fcc37df00dea?variables=W3sidmFyIjoiSmlyYVByb2plY3QubmFtZSIsInZhbCI6eyJtZW1iZXIiOiJKaXJhUHJvamVjdC5uYW1lIiwib3BlcmF0b3IiOiJlcXVhbHMiLCJ2YWx1ZXMiOlsiaXNzdWVzLnJlZGhhdC5jb20vU0FOREJPWCJdfX1d&workstream=00000000b5cc5d88
   Kubesaw Team:
     team_dashboards:
       Sprint Planning Accuracy:
         filename: KUBESAW_Report.pdf
-        filter:
-          "Jira Project Names": ["issues.redhat.com/SANDBOX"]
+        url: https://logilica.io/dashboard/f42ddeac-8520-4709-bd36-5713c8e299d3?variables=W3sidmFyIjoiSmlyYVByb2plY3QubmFtZSIsInZhbCI6eyJtZW1iZXIiOiJKaXJhUHJvamVjdC5uYW1lIiwib3BlcmF0b3IiOiJlcXVhbHMiLCJ2YWx1ZXMiOlsiaXNzdWVzLnJlZGhhdC5jb20vS1VCRVNBVyJdfX0seyJ2YXIiOiJUaW1lIiwidmFsIjp7ImRpbWVuc2lvbiI6IlRpbWUiLCJkYXRlUmFuZ2UiOiJmcm9tIDkwIGRheXMgYWdvIHRvIG5vdyJ9fV0%3D&workstream=00000000b5cc5d88


### PR DESCRIPTION
This PR is a follow-on to #13:  when generating the reports, load the reports using a pre-made URL from the configuration file which has the filter settings embedded in it.

This PR also contains a number of ancillary changes:
- Adds the `url` key to the dashboard section of the configuration file to indicate the URL to use to load the dashboard; this value is obtained from the Logilica UI using the "Copy Link" button, once the filters have been set.
- Renames the `filename` key from the dashboard section of the configuration file to lowercase:  all the fixed keys are now lowercase.
- Removes the `jira_projects` key, which is not used.
- Improves the error messages produced when the respective tool commands crash with an unhandled exception.
- Tightens up the configuration file schema, to require the fixed keys when their parent sub-sections are present and to reject other keys in the fixed sub-sections.
- Removs the unused `DashboardPage.TIMEOUT` definition.
- Picks some lint and nits from `logilica_weekly_report/page_settings.py`, `logilica_weekly_report/playwright_session.py`, et al.
- Removes the indirect dependencies from `requirements.txt` and alphabetizes the remainder.