### PR TITLE
Allow running with no "config" configuration

### DIFF
--- a/logilica_weekly_report/__main__.py
+++ b/logilica_weekly_report/__main__.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 
 import click
+from click import Command
 from jsonschema import ValidationError
 import yaml
 
@@ -121,6 +122,7 @@ def cli(
     }
 
 
+command: Command
 for command in [weekly_report, data_sources]:
     cli.add_command(command)
 

--- a/logilica_weekly_report/cli_weekly_report.py
+++ b/logilica_weekly_report/cli_weekly_report.py
@@ -81,12 +81,11 @@ def weekly_report(
     """
     exit_status = 0
     configuration = context.obj["configuration"]
+    config = configuration.get("config", {})
     logilica_credentials = context.obj["logilica_credentials"]
 
     # If needed, get the credentials now to enable "failing early".
-    google_credentials = (
-        get_google_credentials(configuration["config"]) if output == "gdoc" else None
-    )
+    google_credentials = get_google_credentials(config) if output == "gdoc" else None
 
     remove_downloads = not download_dir_path.exists()
     logging.debug(
@@ -114,9 +113,7 @@ def weekly_report(
         )
         doc = generate_html(pdf_items)
         if output == "gdoc":
-            url = upload_doc(
-                doc.getvalue(), google_credentials, configuration["config"]
-            )
+            url = upload_doc(doc.getvalue(), google_credentials, config)
             click.echo(f"Report uploaded to {url}")
         else:
             click.echo(doc.getvalue(), err=False)


### PR DESCRIPTION
I'm not sure how it happened without my noticing, but the tool seems to have lost the ability to run with a configuration which doesn't include a `"config"` section.  This change adds code to handle that case.

This also adds a couple of lines to quiet a concern from my IDE's linter.