### PR TITLE
Use PyTest to run unit tests

### DIFF
--- a/.github/workflows/python_lint_and_test.yaml
+++ b/.github/workflows/python_lint_and_test.yaml
@@ -25,7 +25,10 @@ jobs:
           # architecture: x64
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt -r tests/requirements.txt -r .github/workflows/requirements.txt
+          python -m pip install \
+              -r requirements.txt \
+              -r tests/requirements.txt \
+              -r .github/workflows/requirements.txt \
       - name: Run python style and linting tools
         run: |
           err=0
@@ -42,22 +45,21 @@ jobs:
           exit $err
       - name: Run tests with coverage
         run: |
-          pip install coverage
-          # Run the unit tests
-          python -m coverage run -a -m unittest discover -v tests
-          # Generate the coverage HTML report
-          python -m coverage html
+          pytest --timeout=300 \
+              --cov-config pyproject.toml \
+              --cov=logilica_weekly_report --cov=tests \
+              --cov-report=term --cov-report=html \
+            >test_run.out
       - name: Publish coverage report to job summary
         # publishing only once
         if: strategy.job-index == 0
         run: |
-          pip install html2text
-          html2text --ignore-images --ignore-links -b 0 htmlcov/index.html >> $GITHUB_STEP_SUMMARY
+          coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
       - name: Upload coverage HTML artifact
         # uploading only once
         if: strategy.job-index == 0
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: Coverage for ${{ github.event.head_commit.id }}
           path: htmlcov
           if-no-files-found: error

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,7 +1,6 @@
 autoflake
 black
-coverage
+coverage[toml]
 docformatter
 flake8
-html2text
 isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,48 @@ recursive = true
 wrap-descriptions = 79
 wrap-summaries = 79
 
+[tool.coverage.run]
+branch = true
+relative_files = true
+source = ["logilica_weekly_report", "tests"]
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+# (Note that these matches are unanchored!)
+exclude_also = [
+    # Don't complain about missing debug-only code:
+    "def __repr__",
+
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+
+    # Don't complain if non-runnable code isn't run:
+    "if 0:",
+    "if __name__ == .__main__.:",
+
+    # Don't complain about abstract methods, they aren't run:
+    "@(abc\\.)?abstractmethod",
+    ]
+format = "markdown"
+skip_empty = true
+
+[tool.coverage.html]
+skip_empty = true
+
 [tool.isort]
 profile = "black"                               # black-compatible (e.g., trailing comma)
 known_first_party = ["logilica_weekly_report"]  # use separate section for project sources
 force_sort_within_sections = true               # don't separate import vs from
 order_by_type = false                           # sort alphabetic regardless of case
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    # note the use of single quote below to denote "raw" (regex) strings in TOML
+    'ignore:builtin type swig\w* has no __module__ attribute:DeprecationWarning',
+]
+empty_parameter_set_mark = "xfail"
+testpaths = ["tests"]
 
 [tool.setuptools]
 packages = ["logilica_weekly_report"]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,1 +1,4 @@
-# None, yet.
+coverage[toml]
+pytest
+pytest-cov
+pytest-timeout


### PR DESCRIPTION
The PR changes our CI test runner from the Python Standard Library `unittest` package to the PyTest package.  And, it generates coverage data using the `pytest-cov` plugin instead of running the tests under `coverage`.

This PR also includes the following:
- The generation of the coverage report included in the GH Action job summary is simplified:  it is now regenerated from the coverage data (in Markdown format) rather than converting the already-generated report from HTML to text.
- The requirements files are updated accordingly.
- The tool configurations are updated: 
  - Added a configuration section for PyTest:
    - configured the location of the test files, to make them easy to find and to avoid the need to specify them on the command line
    - configured PyTest to fail any tests with parameterization lists which are empty
    - added a filter to hide a warning that we don't care about
  - Added some configuration sections for Coverage:
    - omit reporting of files which contain no code (like `__init__.py`)
    - exclude certain source lines from being flagged as not covered
    - measure branch coverage
    - report file paths relative to the package root