### PR TITLE
Change `data-sources` subcommand to use SSO login instead of email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,46 @@
 # logilica-weekly-report
 
-This project exports charts and text from Logilica reports and (will eventually)
-add the content to a Google Doc such as a weekly report.
+This project exports charts and text from Logilica reports and makes them
+available in a variety of formats, including HTML, Markdown, and Google Docs.
+The tool can also be used to configure Logilica integrations, supporting a
+"configuration as code" approach.
 
-The tool is configured via a YAML file which contains configuration options as
-well as a list of teams.  For each team, it specifies a list of Logilica
-dashboards and the team's Jira project.  For each dashboard, it specifies the
-name of an output file (which must not conflict with any other team's dashboards'
-output files) and possibly other attributes.  By default, the file
-`weekly_report.yaml` in the current directory is used, but an alternate path can
-be specified on the command line.
+The tool is configured via a YAML file which contains tool configuration
+options and options for exporting data or configuring Logilica.  By default,
+the file `weekly_report.yaml` in the current directory is used, but an
+alternate path can be specified on the command line.
 
-To onboard a new team, create a new Logilica dashboard for it and add the team
-and the dashboard information to the configuration file.
+For export, the configuration includes a list of teams.  For each team, it
+specifies a list of Logilica dashboards and the team's Jira project.  For each
+dashboard, it specifies the name of an output file (which must not conflict
+with any other team's dashboards' output files) and possibly other attributes.
 
-Credentials for accessing Logilica are provided by the environment variables,
+For configuring Logilica integrations, the configuration provides a list of
+connectors, where each entry is the credential used for the connection, under
+which there is a `connector` type and a list of `membership_boards`,
+`membership_repositories`, or `public_repositories` depending on whether the
+connector is for (e.g., Jira) boards, privately-accessed (e.g. GitHub)
+repositories, or publicly-accessed (e.g., GitHub) repositories, respectively.
+
+To onboard a new team, add connectors for its data sources, create a new
+Logilica dashboard for it, and add the team and the dashboard information to
+the configuration file.
+
+Credentials for accessing Logilica are provided by command line options or by
+the environment variables,
 `LOGILICA_DOMAIN`, `LOGILICA_EMAIL`, and `LOGILICA_PASSWORD`.  (Note to the
 Developer Practices Team:  the appropriate values for the bot account can be
-obtained from the Bitwarden vault.)
+obtained from the Bitwarden vault.)  Access for export uses an "email login",
+which is expected to specify a view-only "bot" account.  Access for
+configuration uses "SSO login" and requires the user to provide his/her own
+credentials for accountability reasons.  The tool normally runs in "headless"
+mode; however, in order to enable the user to perform an SSO login, the
+`data-sources` subcommand opens a browser window during the run.  (You should
+not interact with this window unless it prompts for your SSO credentials;
+otherwise, you are likely to disrupt the functioning of the tool.)
 
-To run the script, check out the Git repo and run:  ```pip install -r requirements.txt .```
+To run the tool, check out the Git repo and run:
+```pip install -r requirements.txt .```
 We recommend doing this inside a [virtual environment](https://docs.python.org/3/library/venv.html).
 (If you are doing development on the tool, you may want to specify `-e` in the
 `pip install` command.)  After installing the tool, you also need to install
@@ -36,28 +57,96 @@ directory, but an alternate path can be specified on the command line.
 
 Help is available on the command line:
 ```text
-$ logilica-weekly-report --help
-Usage: logilica-weekly-report [OPTIONS]
+Usage: logilica-weekly-report [OPTIONS] COMMAND [ARGS]...
 
-  A tool for fetching Logilica reports, extracting their contents, and adding
-  them to a Google Doc.
+  A tool to automate UI interactions with Logilica.
 
 Options:
-  -C, --config FILE          Path to configuration file  [default:
-                             ./weekly_report.yaml]
-  -d, --downloads DIRECTORY  Path to a directory to receive downloaded
-                             files (will be created if it doesn't exist; will
-                             be deleted if created)  [default:
-                             ./lwr_downloaded_pdfs]
-  -D, --pwdebug, --PWD       Enable Playwright debug mode
-  -v, --verbose              Enable verbose mode; specify multiple times to
-                             increase verbosity
-  --help                     Show this message and exit.
+  -C, --config FILE           Path to configuration file  [default:
+                              ./weekly_report.yaml]
+  -o, --output-dir DIRECTORY  Path to a directory to store output if image-
+                              only output is selected  [default: ./output]
+  -D, --pwdebug, --PWD        Enable Playwright debug mode
+  -v, --verbose               Enable verbose mode; specify multiple times to
+                              increase verbosity
+  --help                      Show this message and exit.
+
+Commands:
+  data-sources   Synchronizes configuration of integrations with the...
+  weekly-report  Downloads and processes weekly report for teams...
 
   For more information, see https://github.com/developerproductivity/logilica-
   weekly-report#logilica-weekly-report
 ```
 
+```text
+Usage: logilica-weekly-report weekly-report [OPTIONS]
+
+  Downloads and processes weekly report for teams specified in the
+  configuration.
+
+Options:
+  -u, --username TEXT             Logilica Login Credentials: User Email  [env
+                                  var: LOGILICA_EMAIL; required]
+  -p, --password TEXT             Logilica Login Credentials: Password  [env
+                                  var: LOGILICA_PASSWORD; required]
+  -d, --domain TEXT               Logilica Login Credentials: Organization
+                                  Name  [env var: LOGILICA_DOMAIN; required]
+  -t, --downloads-temp-dir DIRECTORY
+                                  Path to a directory to receive downloaded
+                                  files (will be created if it doesn't exist;
+                                  will be deleted if created)  [default:
+                                  ./lwr_downloaded_pdfs]
+  -I, --input [logilica|local]    Input source -- download from Logilica or
+                                  use pre-downloaded files  [default:
+                                  logilica]
+  -O, --output, --output-type [gdoc|console|images-only|markdown|html|markdown-with-refs|html-with-refs]
+                                  Output format of how individual PDF file is
+                                  processed:
+
+                                  gdoc: HTML with an embedded image
+                                  representing whole dashboard and stored  as
+                                  a Google Doc on Google Drive
+
+                                  console: HTML with an embedded image
+                                  representing whole dashboard to stdout
+
+                                  images-only: Embedded image only as a PNG.
+
+                                  markdown: PDF parsed by docling into
+                                  Markdown, with images embedded in it. Images
+                                  might represent individual charts.
+
+                                  html: PDF parsed by docling into HTML, with
+                                  images embedded in it.  Images might
+                                  represent individual charts.
+
+                                  markdown-with-refs: PDF parsed by docling
+                                  into Markdown, with images stored externally
+                                  and referenced. Images might represent
+                                  individual charts.
+
+                                  html-with-refs: PDF parsed by docling into
+                                  HTML, with images stored externally and
+                                  referenced. Images might represent
+                                  individual charts.  [default: gdoc]
+  -s, --scale FLOAT               Resolution of the images scale factor * 72
+                                  DPI. Higher the number, higher the
+                                  resolution and size of the images  [default:
+                                  1.0]
+  --help                          Show this message and exit.
+```
+
+```text
+Usage: logilica-weekly-report data-sources [OPTIONS]
+
+  Synchronizes configuration of integrations with the configuration file.
+
+Options:
+  -d, --domain TEXT  Logilica Login Credentials: Organization Name  [env var:
+                     LOGILICA_DOMAIN; required]
+  --help             Show this message and exit.
+```
 Some dashboards can be quite slow to load into the UI, so, if you are running
 the tool interactively and wish to track its progress, add a `-v` to the command
 line to see informational messages.  (If you are debugging or just nosy, adding

--- a/logilica_weekly_report/__main__.py
+++ b/logilica_weekly_report/__main__.py
@@ -23,33 +23,6 @@ logging.basicConfig(format="[%(levelname)s] lwr: %(message)s", level=logging.WAR
     epilog="For more information, see https://github.com/developerproductivity/logilica-weekly-report#logilica-weekly-report"
 )
 @click.option(
-    "--username",
-    "-u",
-    envvar="LOGILICA_EMAIL",
-    required=True,
-    show_default=True,
-    show_envvar=True,
-    help="Logilica Login Credentials: User Email",
-)
-@click.password_option(
-    "--password",
-    "-p",
-    envvar="LOGILICA_PASSWORD",
-    show_default=True,
-    show_envvar=True,
-    required=True,
-    help="Logilica Login Credentials: Password",
-)
-@click.option(
-    "--domain",
-    "-d",
-    envvar="LOGILICA_DOMAIN",
-    show_default=True,
-    show_envvar=True,
-    required=True,
-    help="Logilica Login Credentials: Organization Name",
-)
-@click.option(
     "--config",
     "-C",
     "config_file_path",
@@ -90,10 +63,7 @@ logging.basicConfig(format="[%(levelname)s] lwr: %(message)s", level=logging.WAR
 def cli(
     context: click.Context,
     config_file_path: pathlib.Path,
-    domain: str,
     output_dir_path: str,
-    username: str,
-    password: str,
     pwdebug: bool,
     verbose: int,
 ) -> None:
@@ -128,11 +98,6 @@ def cli(
 
     context.ensure_object(dict)
     context.obj["configuration"] = configuration
-    context.obj["logilica_credentials"] = {
-        "username": username,
-        "password": password,
-        "domain": domain,
-    }
     context.obj["output_dir_path"] = output_dir_path
 
 

--- a/logilica_weekly_report/cli_data_sources.py
+++ b/logilica_weekly_report/cli_data_sources.py
@@ -10,9 +10,19 @@ DEFAULT_DOWNLOADS_DIR = "./lwr_downloaded_pdfs"
 
 
 @click.command()
+@click.option(
+    "--domain",
+    "-d",
+    envvar="LOGILICA_DOMAIN",
+    show_default=True,
+    show_envvar=True,
+    required=True,
+    help="Logilica Login Credentials: Organization Name",
+)
 @click.pass_context
 def data_sources(
     context: click.Context,
+    domain: str,
 ) -> None:
     """Synchronizes configuration of integrations with the configuration file.
 
@@ -43,13 +53,13 @@ def data_sources(
 
     exit_status = 0
     configuration = context.obj["configuration"]
-    logilica_credentials = context.obj["logilica_credentials"]
+    logilica_credentials = {"domain": domain}
 
     try:
-        with PlaywrightSession() as page:
+        with PlaywrightSession(headless=False) as page:
             login_page = LoginPage(page=page, credentials=logilica_credentials)
             login_page.navigate()
-            login_page.login()
+            login_page.login_with_sso()
 
             settings_page = SettingsPage(page=page)
             settings_page.sync_integrations(integrations=configuration["integrations"])

--- a/logilica_weekly_report/cli_weekly_report.py
+++ b/logilica_weekly_report/cli_weekly_report.py
@@ -87,18 +87,24 @@ DEFAULT_DOWNLOADS_DIR = "./lwr_downloaded_pdfs"
     show_default=True,
     help="""Output format of how individual PDF file is processed:
 
-    gdoc: HTML with an embedded image represeting whole dashboard and
-        stored as a Google Doc on Google Drive
-    console: HTML with an embedded image represeting whole dashboard to stdout
+    gdoc: HTML with an embedded image representing whole dashboard and stored
+    as a Google Doc on Google Drive
+
+    console: HTML with an embedded image representing whole dashboard to stdout
+
     images-only: Embedded image only as a PNG.
-    markdown: PDF parsed by docling into Markdown, with images embedded
-        in it. Images might represent individual charts.
-    html: PDF parsed by docling into HTML, with images embedded in it.
-        Images might represent individual charts.
-    markdown-with-refs: PDF parsed by docling into Markdown, with images stored
-        externally and referenced. Images might represent individual charts.
+
+    markdown: PDF parsed by docling into Markdown, with images embedded in it.
+    Images might represent individual charts.
+
+    html: PDF parsed by docling into HTML, with images embedded in it.  Images
+    might represent individual charts.
+
+    markdown-with-refs: PDF parsed by docling into Markdown, with images
+    stored externally and referenced. Images might represent individual charts.
+
     html-with-refs: PDF parsed by docling into HTML, with images stored
-        externally and referenced. Images might represent individual charts.
+    externally and referenced. Images might represent individual charts.
     """,
 )
 @click.option(
@@ -188,11 +194,11 @@ def weekly_report(
             scale=scale,
         )
         if output in ("markdown", "html", "markdown-with-refs", "html-with-refs"):
-            format = output.removesuffix("-with-refs")
+            o_format = output.removesuffix("-with-refs")
             embed_images = not output.endswith("-with-refs")
             converter.to_format_multiple(
                 teams=configuration["teams"],
-                format=format,
+                format=o_format,
                 embed_images=embed_images,
             )
         else:

--- a/logilica_weekly_report/cli_weekly_report.py
+++ b/logilica_weekly_report/cli_weekly_report.py
@@ -22,6 +22,33 @@ DEFAULT_DOWNLOADS_DIR = "./lwr_downloaded_pdfs"
 
 @click.command()
 @click.option(
+    "--username",
+    "-u",
+    envvar="LOGILICA_EMAIL",
+    required=True,
+    show_default=True,
+    show_envvar=True,
+    help="Logilica Login Credentials: User Email",
+)
+@click.password_option(
+    "--password",
+    "-p",
+    envvar="LOGILICA_PASSWORD",
+    show_default=True,
+    show_envvar=True,
+    required=True,
+    help="Logilica Login Credentials: Password",
+)
+@click.option(
+    "--domain",
+    "-d",
+    envvar="LOGILICA_DOMAIN",
+    show_default=True,
+    show_envvar=True,
+    required=True,
+    help="Logilica Login Credentials: Organization Name",
+)
+@click.option(
     "--downloads-temp-dir",
     "-t",
     "downloads_temp_dir",
@@ -87,6 +114,9 @@ DEFAULT_DOWNLOADS_DIR = "./lwr_downloaded_pdfs"
 @click.pass_context
 def weekly_report(
     context: click.Context,
+    username: str,
+    password: str,
+    domain: str,
     downloads_temp_dir: Path,
     source: str,
     output: str,
@@ -121,7 +151,11 @@ def weekly_report(
     exit_status = 0
     configuration = context.obj["configuration"]
     config = configuration.get("config", {})
-    logilica_credentials = context.obj["logilica_credentials"]
+    logilica_credentials = {
+        "username": username,
+        "password": password,
+        "domain": domain,
+    }
     output_dir_path = context.obj["output_dir_path"]
 
     # If needed, get the credentials now to enable "failing early".
@@ -141,7 +175,7 @@ def weekly_report(
             with PlaywrightSession() as page:
                 login_page = LoginPage(page=page, credentials=logilica_credentials)
                 login_page.navigate()
-                login_page.login()
+                login_page.login_with_email()
 
                 dashboard_page = DashboardPage(page=page)
                 dashboard_page.download_team_dashboards(

--- a/logilica_weekly_report/page_login.py
+++ b/logilica_weekly_report/page_login.py
@@ -13,6 +13,7 @@ class LoginPage:
         self.page = page
         self.credentials: dict[str, Any] = credentials
         self.email_login_button = page.get_by_role("button", name="Log in With Email")
+        self.sso_login_button = page.get_by_role("button", name="Log in With SSO")
         self.domain_field = page.locator("#domain")
         self.email_field = page.locator("#email")
         self.password_field = page.locator("#password")
@@ -21,14 +22,25 @@ class LoginPage:
     def navigate(self):
         self.page.goto(self.LOGILICA_LOGIN)
 
-    def login(self):
-        logging.info("Logging into Logilica")
+    def login_with_email(self):
+        logging.info("Logging into Logilica via email")
         self.email_login_button.click()
         self.domain_field.fill(self.credentials["domain"])
         self.email_field.fill(self.credentials["username"])
         self.password_field.fill(self.credentials["password"])
         self.login_button.click()
 
+        self.complete_login()
+
+    def login_with_sso(self):
+        logging.info("Logging into Logilica via SSO")
+        self.sso_login_button.click()
+        self.domain_field.fill(self.credentials["domain"])
+        self.login_button.click()
+
+        self.complete_login()
+
+    def complete_login(self):
         try:
             expect(self.page).not_to_have_url(self.LOGILICA_LOGIN)
         except AssertionError:


### PR DESCRIPTION
The Logilica CLI tool offers two subcommands, one which performs a "read" (export) function and one which performs a "write" (configuration) function.  Currently, both commands use the same login flow in the Logilica UI, which requires "email login".  However, the DPROD bot account (which we've been using for export) does not have permission to perform write operations in Logilica...which is as it should be -- write operations should be accountable, and therefore should not be performed by a "bot" account to which multiple people have access.

This PR changes the `data-sources` command to use SSO login, instead, which requires the user of the tool to use their own credentials, instead of using a bot account.

- In the `LoginPage` class, the original method has been renamed (to `login_with_email()`) and there is now a second method (`login_with_sso()`), and the class instantiation captures locators for both buttons.  The common code at the end of the methods has been refactored into a shared subroutine.
- The `weekly-report` subcommand still uses the same method, albeit via the new name; the `data-sources` subcommand now uses the new method.
- Because SSO login will likely require the user to authenticate, the `data-sources` subcommand no longer runs in "headless" mode and displays the captive browser window, so that the User can supply their credentials if required.  This is rather ugly, but I couldn't come up with a better way.
- Since the username and password values are not required for the `data-sources` subcommand, I moved all three command line options from global options to the `weekly-report` subcommand and duplicated the `domain` option on the `data-sources` subcommand.  (So, their position on the command line will change, as well.)
- I fixed the formatting of the help text for the `weekly-report` subcommand `--output` option.
- I updated the `README.md` file to cover the `data-sources` capability, and I updated the included help text.
- I picked a piece of lint that my IDE flagged.