### PR TITLE
DPROD-814: add 16 non-deprecated devfile/ repos for import

### DIFF
--- a/logilica-cli.yaml
+++ b/logilica-cli.yaml
@@ -116,6 +116,8 @@ integrations:
       - codeready-toolchain/workload-analyzer
       - developerproductivity/costpuller
       - developerproductivity/logilica-cli
+      - developerproductivity/data-ingestion
+      - developerproductivity/gh-actions-exp
       - konflux-ci/build-definitions
       - konflux-ci/docs
       - konflux-ci/e2e-tests
@@ -151,7 +153,21 @@ integrations:
       - redhat-developer/vscode-java
       - redhat-developer/vscode-microprofile
       - redhat-developer/vscode-quarkus
+      - redhat-developer/podman-desktop-demo
+      - redhat-developer/podman-desktop-image-checker-openshift-ext
+      - redhat-developer/podman-desktop-redhat-account-ext
+      - redhat-developer/podman-desktop-redhat-pack-ext
+      - redhat-developer/podman-desktop-rhel-ext
+      - redhat-developer/podman-desktop-sandbox-ext
+      - redhat-developer/rhdh-plugin-registry
       - redhat-performance/opl
+      - redhat-openshift-builds/catalog
+      - redhat-openshift-builds/operator
+      - redhat-openshift-builds/release
+      - redhat-openshift-builds/samples
+      - redhat-openshift-builds/shipwright-io
+      - redhat-openshift-builds/shipwright-ip-build
+      - redhat-openshift-builds/strategy-catalog
   dprod-public-bot:
     connector: GitHub
     public_repositories:
@@ -264,6 +280,11 @@ integrations:
       - che-samples/web-python-gae-simple
       - che-samples/web-python2.7-simple
       - che-samples/web-rails-simple
+      - containers/podman-desktop-extension-ai-lab
+      - containers/podman-desktop-extension-ai-lab-playground-images
+      - containers/podman-desktop-internal
+      - containers/podmandesktop-media
+      - crc-org/crc-extension
       - devfile-samples/devfile-sample-code-with-quarkus
       - devfile-samples/devfile-sample-dotnet60-basic
       - devfile-samples/devfile-sample-go-basic
@@ -298,6 +319,20 @@ integrations:
       - eclipse-jdtls/eclipse.jdt.ls
       - eclipse-lsp4mp/lsp4mp
       - openshift/console
+      - orgs/podman-desktop
+      - podman-desktop/e2e
+      - podman-desktop/extension-bootc
+      - podman-desktop/extension-layers-explorer
+      - podman-desktop/extension-minikube
+      - podman-desktop/extension-podman-quadiet
+      - podman-desktop/extension-template-full
+      - podman-desktop/extension-template-minimal
+      - podman-desktop/extension-template-webview
+      - podman-desktop/podman-desktop
+      - podman-desktop/podman-desktop-catalog
+      - podman-desktop/prereleases
+      - podman-desktop/telemetry
+      - podman-desktop/testing-prereleases
       - redhat-ai-dev/ai-lab-template
       - redhat-ai-dev/ai-lab-app
       - redhat-ai-dev/model-catalog-template

--- a/logilica-cli.yaml
+++ b/logilica-cli.yaml
@@ -309,6 +309,22 @@ integrations:
       - devfile-samples/web-coolstore
       - devfile/devworkspace-generator
       - devfile/registry
+      - devfile/developer-images
+      - devfile/alizer
+      - devfile/registry-support
+      - devfile/devfile-web
+      - devfile/cloud-dev-images
+      - devfile/api
+      - devfile/devworkspace-operator
+      - devfile/library
+      - devfile/registry-operator
+      - devfile/vscode-walkthrough-extension
+      - devfile/devfile-docker-plugin
+      - devfile/kubectl-debug-ide
+      - devfile/integration-tests
+      - devfile/devworkspace-operator-docs
+      - devfile/devfile.github.io
+      - devfile/pr-preview
       - eclipse-che/che-dashboard
       - eclipse-che/che-operator
       - eclipse-che/che-plugin-registry


### PR DESCRIPTION
From talking with the team, they have some lower touch repos in `devfile/` that we should include in Logilica for completeness. This PR adds them, and I'll need to run the tool and do an import if there are no concerns. There are 21 repos in their org, 3 are marked deprecated and don't need to be imported, and 2 are already in our config. This PR adds the additional 16 repos.

I had this one build on the updated list from 811, thinking that would be the first to merge, and it would be simpler than updating it after, but I'm happy to adjust if that was the wrong move. 

Maps to DPROD-814