### PR TITLE
Fix 2 more repo name typos

### DIFF
--- a/logilica-cli.yaml
+++ b/logilica-cli.yaml
@@ -283,7 +283,7 @@ integrations:
       - containers/podman-desktop-extension-ai-lab
       - containers/podman-desktop-extension-ai-lab-playground-images
       - containers/podman-desktop-internal
-      - containers/podmandesktop-media
+      - containers/podman-desktop-media
       - crc-org/crc-extension
       - devfile-samples/devfile-sample-code-with-quarkus
       - devfile-samples/devfile-sample-dotnet60-basic
@@ -340,7 +340,7 @@ integrations:
       - podman-desktop/extension-bootc
       - podman-desktop/extension-layers-explorer
       - podman-desktop/extension-minikube
-      - podman-desktop/extension-podman-quadiet
+      - podman-desktop/extension-podman-quadlet
       - podman-desktop/extension-template-full
       - podman-desktop/extension-template-minimal
       - podman-desktop/extension-template-webview


### PR DESCRIPTION
I missed two typos in podman-desktop/extension-podman-quadlet & containers/podman-desktop-media before running the import (i instead of l, and missing -). I've already deleted the typo'd ones out of Logilica, but we need to make sure the config is correct for future imports. 

Cleans up DPROD-811